### PR TITLE
add slack notification to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
 before_script:
 - cd vitro && git checkout 510c6a296654b4ca664848a5ab0d44540cdb1ce7 . && cd ..
 - cd vivo && git checkout e26973ee1c466c462d236d1f058a678573f8b23a . && cd ..
+notifications:
+  slack: tetherless:WJlLSSEGpRO44hbYlNbabTG0


### PR DESCRIPTION
Travis CI will notify our slack channel #travis-ci on build results
