### PR TITLE
Making the accessURL of a distribution clickable

### DIFF
--- a/productMods/config/listViewConfig-accessURL.xml
+++ b/productMods/config/listViewConfig-accessURL.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<!-- VIVO-specific default list view config file for object properties 
+    
+     See guidelines in vitro/doc/list_view_configuration_guidelines.txt -->
+
+<list-view-config>
+    <query-select>    
+        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;  
+        SELECT ?value
+        WHERE {
+                ?subject ?property ?value 
+        }
+    </query-select>
+
+    <query-construct>
+        
+        CONSTRUCT {
+            ?subject ?property ?value 
+        } WHERE {
+                ?subject ?property ?value 
+        }
+    </query-construct>
+    
+    <template>propStatement-accessURL.ftl</template>
+</list-view-config>

--- a/productMods/config/listViewConfig-downloadURL.xml
+++ b/productMods/config/listViewConfig-downloadURL.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<!-- VIVO-specific default list view config file for object properties 
+    
+     See guidelines in vitro/doc/list_view_configuration_guidelines.txt -->
+
+<list-view-config>
+    <query-select>    
+        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;  
+        SELECT ?value
+        WHERE {
+                ?subject ?property ?value 
+        }
+    </query-select>
+
+    <query-construct>
+        
+        CONSTRUCT {
+            ?subject ?property ?value 
+        } WHERE {
+                ?subject ?property ?value 
+        }
+    </query-construct>
+    
+    <template>propStatement-downloadURL.ftl</template>
+</list-view-config>

--- a/productMods/templates/freemarker/body/partials/individual/propStatement-accessURL.ftl
+++ b/productMods/templates/freemarker/body/partials/individual/propStatement-accessURL.ftl
@@ -1,0 +1,17 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- VIVO-specific default data property statement template. 
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+<@showStatement statement />
+
+<#macro showStatement statement>
+    <a href="${statement.value!}" title="Access URL" target="_blank">${statement.value!"Access URL not found"}</a>
+</#macro>
+
+
+
+
+

--- a/productMods/templates/freemarker/body/partials/individual/propStatement-downloadURL.ftl
+++ b/productMods/templates/freemarker/body/partials/individual/propStatement-downloadURL.ftl
@@ -1,0 +1,17 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- VIVO-specific default data property statement template. 
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+<@showStatement statement />
+
+<#macro showStatement statement>
+    <a href="${statement.value!}" title="Download URL" target="_blank">${statement.value!"Download URL not found"}</a>
+</#macro>
+
+
+
+
+

--- a/rdf/display/everytime/vivoListViewConfig.rdf
+++ b/rdf/display/everytime/vivoListViewConfig.rdf
@@ -96,4 +96,8 @@
         <display:listViewConfigFile rdf:datatype="http://www.w3.org/2001/XMLSchema#string">listViewConfig-accessURL.xml</display:listViewConfigFile>
     </rdf:Description>
 
+    <rdf:Description rdf:about="http://info.deepcarbon.net/schema#downloadURL">
+        <display:listViewConfigFile rdf:datatype="http://www.w3.org/2001/XMLSchema#string">listViewConfig-downloadURL.xml</display:listViewConfigFile>
+    </rdf:Description>
+
 </rdf:RDF>

--- a/rdf/display/everytime/vivoListViewConfig.rdf
+++ b/rdf/display/everytime/vivoListViewConfig.rdf
@@ -92,4 +92,8 @@
         <display:listViewConfigFile rdf:datatype="http://www.w3.org/2001/XMLSchema#string">listViewConfig-scopusId.xml</display:listViewConfigFile>
     </rdf:Description>
         
+    <rdf:Description rdf:about="http://info.deepcarbon.net/schema#accessURL">
+        <display:listViewConfigFile rdf:datatype="http://www.w3.org/2001/XMLSchema#string">listViewConfig-accessURL.xml</display:listViewConfigFile>
+    </rdf:Description>
+
 </rdf:RDF>


### PR DESCRIPTION
Modified the list view configuration for the dco:accessURL to use a new
.xml file specifically for the accessURL property. Added the xml, which
points to a new template file for the accessURL.
