### PR TITLE
Moved 'member of' to property group overview

### DIFF
--- a/rdf/display/everytime/PropertyConfig.n3
+++ b/rdf/display/everytime/PropertyConfig.n3
@@ -179,7 +179,7 @@ local:hasMemberRoleConfig a :ObjectPropertyDisplayConfig ;
     vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
     vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;
     vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.AddMemberRoleToPersonGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> .
+    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
 
 local:orgHasMemberRoleContext a :ConfigContext ;
     :hasConfiguration local:orgHasMemberRoleConfig ;

--- a/rdf/display/everytime/PropertyConfig.n3
+++ b/rdf/display/everytime/PropertyConfig.n3
@@ -174,7 +174,7 @@ local:hasMemberRoleContext a :ConfigContext ;
 local:hasMemberRoleConfig a :ObjectPropertyDisplayConfig ;
     :listViewConfigFile "listViewConfig-roleContributesTo.xml"^^xsd:string ;
     :displayName "member of" ;
-    vitro:displayRankAnnot 50;
+    vitro:displayRankAnnot 2;
     vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
     vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
     vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;


### PR DESCRIPTION
Since we've removed associatedDCOTeam from a person we need to display
the team membership in the overview tab instead of affiliation tab.
