### PR TITLE
Hide and auto-generate modification note text

### DIFF
--- a/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
+++ b/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
@@ -99,10 +99,10 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         <input type="hidden" name="modifiedOn" id="modifiedOn" label="modifiedOn" size="30" role="input" value="${modifiedOnValue}">
     <#--</p>-->
 
-    <p>
+    <#--<p>-->
         <#--<label for="modificationNoteText">${i18n().modification_label} ${requiredHint}:</label>-->
         <input type="hidden" name="modificationNoteText" id="modificationNoteText" label="modificationNoteText" size="50" role="input" value="${modificationNoteTextValue}">
-    </p>
+    <#--</p>-->
 
     <p class="submit">
         <input type="submit" id="submit" value="${i18n().create_entry}" role="button" />

--- a/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
+++ b/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
@@ -100,8 +100,8 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <#--</p>-->
 
     <p>
-        <label for="modificationNoteText">${i18n().modification_label} ${requiredHint}:</label>
-        <input type="text" name="modificationNoteText" id="modificationNoteText" label="modificationNoteText" size="50" role="input" value="${modificationNoteTextValue}">
+        <#--<label for="modificationNoteText">${i18n().modification_label} ${requiredHint}:</label>-->
+        <input type="hidden" name="modificationNoteText" id="modificationNoteText" label="modificationNoteText" size="50" role="input" value="${modificationNoteTextValue}">
     </p>
 
     <p class="submit">
@@ -171,6 +171,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     document.getElementById("modifiedByUri").value = creatorUri;
 </script>
 
+<#assign creatorName = "${user.firstName} ${user.lastName}" >
+<script type="text/javascript">
+    var creatorName = '${creatorName}';
+    var modificationNoteText = "Created by " + creatorName;
+    document.getElementById("modificationNoteText").value = modificationNoteText;
+</script>
 
 ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/js/jquery-ui/css/smoothness/jquery-ui-1.8.9.custom.css" />')}
 ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/templates/freemarker/edit/forms/css/customForm.css" />')}


### PR DESCRIPTION
- The modificationNoteText field is now hidden and auto-generated to "Created by firstName lastName".
- The firstName and lastName fields are from the user account.

![screen shot 2016-02-01 at 7 34 28 pm](https://cloud.githubusercontent.com/assets/8951064/12736214/522e6e8a-c91c-11e5-85c2-f7b371fb0724.png)
