### PR TITLE
modifiedBy built based on production or test

### DIFF
--- a/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
+++ b/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
@@ -224,7 +224,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 </script>
 
 <#assign creatorUrl = "${user.profileUrl}" >
-<#assign origuri = "${user.uri}" >
+<#assign defaultNamespace = "${user.defaultNamespace}" >
 <script type="text/javascript">
     // this is the display URL of the person editing this project update.
     var creatorUrlEncoded = '${creatorUrl}';
@@ -241,14 +241,11 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     var n = creatorUrlDecoded.lastIndexOf("/");
     var bas = n == -1 ? "" : creatorUrlDecoded.substring(n+1);
 
-    // this is the uri of the project we're adding this update to. We're interested in the namespace part
-    // which is the same as the namespace part of the user's uri
-    var origuri = '${origuri}';
-    var s = origuri.lastIndexOf("/");
-    var ns = s == -1 ? "" : origuri.substring(0,s);
+    // we're getting this from configuration
+    var dns = '${defaultNamespace}';
 
     // if either the end of the uri is empty or the namespace is empty then we just don't put anything there
-    var userUri = (s == -1 || n == -1) ? "" : ns + '/' + bas ;
+    var userUri = n == -1 ? "" : dns + bas;
 
     // the uri of the person editing this page is the namespace part of the project uri plus the ending of the display url
     document.getElementById("modifiedByUri").value = userUri;

--- a/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
+++ b/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
@@ -152,7 +152,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <#--<p>-->
         <#--<label for="modifiedByUri">${i18n().created_by}:</label>-->
-        <input type="hidden" name="modifiedByUri" id="modifiedByUri" label="modifiedByUri" size="30" role="input" value="${modifiedByUriValue}">
+        <input type="text" name="modifiedByUri" id="modifiedByUri" label="modifiedByUri" size="30" role="input" value="${modifiedByUriValue}">
         <#--<a href="${user.profileUrl}" class="verifyMatch"  title="${i18n().verify_match_capitalized}">-->
             <#--(${i18n().verify_match_capitalized})-->
         <#--</a>-->
@@ -224,11 +224,34 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 </script>
 
 <#assign creatorUrl = "${user.profileUrl}" >
+<#assign origuri = "${user.uri}" >
 <script type="text/javascript">
+    // this is the display URL of the person editing this project update.
     var creatorUrlEncoded = '${creatorUrl}';
+
+    // in test this url is encoded so decode it
     var creatorUrlDecoded = decodeURIComponent(creatorUrlEncoded);
+
+    // this is what we used before, but doesn't work in production
+    // in test the profile url is /vivo/display?uri=http://info.deepcarbon.net/individual/<end-of-uri>
+    // in production the profile url is /vivo/display/<end-of-uri>
     var creatorUri = creatorUrlDecoded.substring(21);
-    document.getElementById("modifiedByUri").value = creatorUri;
+
+    // grab the last slash in the url, we want what's after that
+    var n = creatorUrlDecoded.lastIndexOf("/");
+    var bas = n == -1 ? "" : creatorUrlDecoded.substring(n+1);
+
+    // this is the uri of the project we're adding this update to. We're interested in the namespace part
+    // which is the same as the namespace part of the user's uri
+    var origuri = '${origuri}';
+    var s = origuri.lastIndexOf("/");
+    var ns = s == -1 ? "" : origuri.substring(0,s);
+
+    // if either the end of the uri is empty or the namespace is empty then we just don't put anything there
+    var userUri = (s == -1 || n == -1) ? "" : ns + '/' + bas ;
+
+    // the uri of the person editing this page is the namespace part of the project uri plus the ending of the display url
+    document.getElementById("modifiedByUri").value = userUri;
 </script>
 
 <#assign creatorName = "${user.firstName} ${user.lastName}" >

--- a/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
+++ b/productMods/templates/freemarker/edit/forms/addProjectUpdate.ftl
@@ -152,7 +152,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <#--<p>-->
         <#--<label for="modifiedByUri">${i18n().created_by}:</label>-->
-        <input type="text" name="modifiedByUri" id="modifiedByUri" label="modifiedByUri" size="30" role="input" value="${modifiedByUriValue}">
+        <input type="hidden" name="modifiedByUri" id="modifiedByUri" label="modifiedByUri" size="30" role="input" value="${modifiedByUriValue}">
         <#--<a href="${user.profileUrl}" class="verifyMatch"  title="${i18n().verify_match_capitalized}">-->
             <#--(${i18n().verify_match_capitalized})-->
         <#--</a>-->

--- a/src/edu/cornell/mannlib/vitro/webapp/web/templatemodels/User.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/web/templatemodels/User.java
@@ -1,0 +1,102 @@
+/* $This file is distributed under the terms of the license in /doc/license.txt$ */
+
+package edu.cornell.mannlib.vitro.webapp.web.templatemodels;
+
+import java.util.Collection;
+
+import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
+import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
+import edu.cornell.mannlib.vitro.webapp.auth.identifier.RequestIdentifiers;
+import edu.cornell.mannlib.vitro.webapp.auth.identifier.common.HasProfile;
+import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
+import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.RevisionInfoController;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.SiteAdminController;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
+import edu.cornell.mannlib.vitro.webapp.search.controller.IndexController;
+
+public class User extends BaseTemplateModel {
+    private final VitroRequest vreq;
+    private final UserAccount currentUser;
+    private final String profileUrl;
+    
+    public User(VitroRequest vreq) {
+        this.vreq = vreq;
+        this.currentUser = LoginStatusBean.getCurrentUser(vreq);
+        this.profileUrl = figureAssociatedProfileUrl();
+    }
+    
+	private String figureAssociatedProfileUrl() {
+        IdentifierBundle ids = RequestIdentifiers.getIdBundleForRequest(vreq);
+		Collection<String> uris = HasProfile.getProfileUris(ids);
+        if (uris.isEmpty()) {
+        	return "";
+        }
+        
+        String uri = uris.iterator().next();
+        String url = UrlBuilder.getIndividualProfileUrl(uri, vreq);
+        if (url == null) {
+        	return "";
+        }
+        
+        return url;
+	}
+	
+	/* Template properties */
+
+	public boolean isLoggedIn() {
+        return currentUser != null;
+    }
+    
+    public String getEmailAddress() {
+		return (currentUser == null) ? "" : currentUser.getEmailAddress();
+    }
+    
+    public String getLoginName() {
+    	if (currentUser == null) {
+    		return "";
+    	} 
+
+    	if (currentUser.getFirstName().isEmpty()) {
+    		return currentUser.getEmailAddress();
+    	}
+    	
+    	return currentUser.getFirstName();
+    }
+    
+    public String getFirstName() {
+        return currentUser == null ? "" : currentUser.getFirstName();
+    }
+    
+    public String getLastName() {
+        return currentUser == null ? "" : currentUser.getLastName();
+    }
+    
+    /* uri of the subject this object is being attached to
+       it is never null
+    */
+    public String getUri() {
+        return currentUser == null ? "" : currentUser.getUri();
+    }
+    
+    public boolean getHasSiteAdminAccess() {
+    	return PolicyHelper.isAuthorizedForActions(vreq, SiteAdminController.REQUIRED_ACTIONS);
+    }
+    
+    public boolean getHasRevisionInfoAccess() {
+    	return PolicyHelper.isAuthorizedForActions(vreq, RevisionInfoController.REQUIRED_ACTIONS);
+    }
+    
+    public boolean isAuthorizedToRebuildSearchIndex() {
+        return PolicyHelper.isAuthorizedForActions(vreq, IndexController.REQUIRED_ACTIONS);
+    }
+    
+    public boolean getHasProfile() {
+    	return !profileUrl.isEmpty();
+    }
+    
+    public String getProfileUrl() {
+    	return profileUrl;
+    }
+}

--- a/src/edu/cornell/mannlib/vitro/webapp/web/templatemodels/User.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/web/templatemodels/User.java
@@ -15,16 +15,19 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.RevisionInfoContro
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.SiteAdminController;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.search.controller.IndexController;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 
 public class User extends BaseTemplateModel {
     private final VitroRequest vreq;
     private final UserAccount currentUser;
     private final String profileUrl;
+    private final String defaultNamespace;
     
     public User(VitroRequest vreq) {
         this.vreq = vreq;
         this.currentUser = LoginStatusBean.getCurrentUser(vreq);
         this.profileUrl = figureAssociatedProfileUrl();
+		this.defaultNamespace = ConfigurationProperties.getBean(vreq).getProperty("Vitro.defaultNamespace");
     }
     
 	private String figureAssociatedProfileUrl() {
@@ -78,6 +81,10 @@ public class User extends BaseTemplateModel {
     */
     public String getUri() {
         return currentUser == null ? "" : currentUser.getUri();
+    }
+    
+    public String getDefaultNamespace() {
+        return defaultNamespace;
     }
     
     public boolean getHasSiteAdminAccess() {


### PR DESCRIPTION
The issue was that the profileUrl being used to set the person's uri in
the project update form is different between test and production. The
reason they are different is that in production it is
/vivo/display/<end-of-uri> whereas in test it is
/vivo/display?uri=<person's uri> which is good because it recognizes
that it is in test and not productio so builds the display uri
appropriately.

Because they are different we need a different approach to building the
person's uri. Unfortunately it isn't just available to be used here, so
we have to construct it.

We construct it given the subject (project) that this object (project
update) is being added to. That's why we modified the User.java class,
to make it available. Otherwise it's not available. Then we add on the
end of the display value, and this gives us the person's uri.
