### PR TITLE
slack notification to post to dco-ds channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
 - cd vitro && git checkout 510c6a296654b4ca664848a5ab0d44540cdb1ce7 . && cd ..
 - cd vivo && git checkout e26973ee1c466c462d236d1f058a678573f8b23a . && cd ..
 notifications:
-  slack: tetherless:WJlLSSEGpRO44hbYlNbabTG0
+  slack: tetherless:AGpM1DHijgp8fBmwH3ac8DYO


### PR DESCRIPTION
Updated slack notification settings in Travis-CI config such that travis-ci notifications will be posted to the private dco-ds slack channel.
