### PR TITLE
Display of dco-id at top of page using https

### DIFF
--- a/productMods/templates/freemarker/body/individual/individual-vitro.ftl
+++ b/productMods/templates/freemarker/body/individual/individual-vitro.ftl
@@ -50,7 +50,7 @@
             </#if>
 	    <#if dcoId??>
             	<h2 id="dcoId">
-            	    DCO ID <a href="http://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
+            	    DCO ID <a href="https://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
             	</h2>
             </#if>
         </header>

--- a/themes/dco/templates/individual--foaf-person.ftl
+++ b/themes/dco/templates/individual--foaf-person.ftl
@@ -91,7 +91,7 @@
             </#if>
 	    	<#if dcoId??>
                 <h2 id="dcoId">
-                    DCO ID: <a href="http://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
+                    DCO ID: <a href="https://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
                 </h2>
             </#if>
             

--- a/themes/wilma/templates/individual--foaf-person.ftl
+++ b/themes/wilma/templates/individual--foaf-person.ftl
@@ -88,7 +88,7 @@
             </#if>
 	    <#if dcoId??>
                 <h2 id="dcoId">
-                    DCO ID <a href="http://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
+                    DCO ID <a href="https://dx.deepcarbon.net/${dcoId!}" target="_blank" title="DCO-ID">${dcoId!}</a>
                 </h2>
             </#if>
             <!-- Positions -->   


### PR DESCRIPTION
Changed how the dco-id at the top of an instance page is displayed by
making it point to https://dx.deepcarbon.net rather than http://.
