### PR TITLE
ServerInfo to get props from runtime.properties

### DIFF
--- a/config/runtime.properties
+++ b/config/runtime.properties
@@ -244,10 +244,12 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
 DCO.baseURL = https://info.deepcarbon.net/vivo
 DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
 DCO.ckanURL = http://data.deepcarbon.net/ckan
+DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://info.deepcarbon.net/endpoint
+DCO.endpoint = http://localhost:3030
 DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
 DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/config/runtime.properties
+++ b/config/runtime.properties
@@ -248,8 +248,8 @@ DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://localhost:3030
-DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
-DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+DCO.endpoint = http://128.213.3.13:3030
+DCO.sparqlQueryAPI = http://128.213.3.13:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://128.213.3.13:8080/vivo/api/sparqlUpdate
 DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/config/runtime.properties
+++ b/config/runtime.properties
@@ -242,14 +242,14 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
 #homePage.geoFocusMaps=enabled
 
 DCO.baseURL = https://info.deepcarbon.net/vivo
-DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
+DCO.handleURL = http://deepcarbon.tw.rpi.edu:8080/dcohandleservice/services/handles/
 DCO.ckanURL = http://data.deepcarbon.net/ckan
-DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
+DCO.ckanApiKey = 96c00a49-9604-42ca-84b1-e43674f6c0f8
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://128.213.3.13:3030
-DCO.sparqlQueryAPI = http://128.213.3.13:8080/vivo/admin/sparqlquery
-DCO.sparqlUpdateAPI = http://128.213.3.13:8080/vivo/api/sparqlUpdate
+DCO.endpoint = http://deepcarbon.tw.rpi.edu:3030
+DCO.sparqlQueryAPI = http://deepcarbon.tw.rpi.edu:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://deepcarbon.tw.rpi.edu:8080/vivo/api/sparqlUpdate
 DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/config/runtime.properties
+++ b/config/runtime.properties
@@ -9,277 +9,143 @@
 #
 # -----------------------------------------------------------------------------
 
+# 
+# This namespace will be used when generating URIs for objects created in the 
+# editor. In order to serve linked data, the default namespace must be composed 
+# as follows (optional elements in parentheses):
+#
+# scheme + server_name (+ port) (+ servlet_context) + "/individual/"
+# 
+# For example, Cornell's default namespace is:
+#
+# http://vivo.cornell.edu/individual/
+#
+Vitro.defaultNamespace = http://info.deepcarbon.net/individual/
 
-# -----------------------------------------------------------------------------
-# BASIC PROPERTIES
-# -----------------------------------------------------------------------------
+# 
+# URL of Solr context used in local VIVO search. This will usually consist of:
+#     scheme + server_name + port + vivo_webapp_name + "solr"
+# In the standard installation, the Solr context will be on the same server as VIVO,
+# and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
+# above) + "solr"
+#   Example:
+#     vitro.local.solr.url = http://localhost:8080/vivosolr
+vitro.local.solr.url = http://128.213.3.13:8080/vivosolr
 
-  # 
-  # This namespace will be used when generating URIs for objects created in the 
-  # editor. In order to serve linked data, the default namespace must be composed 
-  # as follows (optional elements in parentheses): 
-  #
-  # scheme + server_name (+ port) (+ servlet_context) + "/individual/"
-  # 
-  # For example, Cornell's default namespace is:
-  #
-  # http://vivo.cornell.edu/individual/
-  #
-Vitro.defaultNamespace = http://localhost:8080/vivo/individual/
+#
+# Email parameters which VIVO can use to send mail. If these are left empty, 
+# the "Contact Us" form will be disabled and users will not be notified of
+# changes to their accounts.
+#
+#email.smtpHost = smtp.mydomain.edu
+#email.replyTo = vivoAdmin@mydomain.edu
 
-  #
-  # The email address of the root user for the VIVO application. The password 
-  # for this user is initially set to "rootPassword", but you will be asked to 
-  # change the password the first time you log in. 
-  #
-rootUser.emailAddress = cheny18@rpi.edu
-
-  #
-  # The basic parameters for a database connection. Change the end of the 
-  # URL to reflect your database name (if it is not "vitrodb"). Change the username 
-  # and password to match the authorized database user you created.
-  #
+#
+# The basic parameters for a database connection. Change the end of the 
+# URL to reflect your database name (if it is not "vitrodb"). Change the username 
+# and password to match the authorized database user you created.
+#
 VitroConnection.DataSource.url = jdbc:mysql://localhost/vivo
 VitroConnection.DataSource.username = vivo
 VitroConnection.DataSource.password = vivo
 
-  #
-  # Email parameters which VIVO can use to send mail. If these are left empty, 
-  # the "Contact Us" form will be disabled and users will not be notified of
-  # changes to their accounts.
-  #
-email.smtpHost = smtp.mydomain.edu
-email.replyTo = vivoAdmin@mydomain.edu
-
-  # 
-  # URL of Solr context used in local VIVO search. This will usually consist of:
-  #     scheme + server_name + port + vivo_webapp_name + "solr"
-  # In the standard installation, the Solr context will be on the same server as VIVO,
-  # and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
-  # above) + "solr"
-  #   Example:
-  #     vitro.local.solr.url = http://localhost:8080/vivosolr
-  #
-vitro.local.solr.url = http://localhost:8080/vivosolr
-
-
-# -----------------------------------------------------------------------------
-# LINKING USER ACCOUNTS TO PROFILE PAGES
-# -----------------------------------------------------------------------------
-
-  #
-  # How is a logged-in user associated with a particular Individual? One way is 
-  # for the Individual to have a property whose value is the username of the user.
-  # This value should be the URI for that property.
-  #
-selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
-
-
-# -----------------------------------------------------------------------------
-# USING AN EXTERNAL AUTHENTICATION SYSTEM
-# -----------------------------------------------------------------------------
-
-  #
-  # If an external authentication system like Shibboleth or CUWebAuth is to be
-  # used, this property says which HTTP header will contain the user ID from 
-  # the authentication system. If such a system is not to be used, leave this 
-  # commented out. Consult the installation instructions for more details. 
-  #
-#externalAuth.netIdHeaderName = remote_userID 
-
-
-# -----------------------------------------------------------------------------
-# TUNING THE DATABASE CONNECTION POOL
-# -----------------------------------------------------------------------------
-
-  #
-  # The maximum number of active connections in the database connection pool.
-  # Increase this value to support a greater number of concurrent page requests.
-  #
+#
+# The maximum number of active connections in the database connection pool.
+# Increase this value to support a greater number of concurrent page requests.
+#
 VitroConnection.DataSource.pool.maxActive = 40
 
-  #
-  # The maximum number of database connections that will be allowed
-  # to remain idle in the connection pool.  Default is 25%
-  # of the maximum number of active connections.
-  #
+#
+# The maximum number of database connections that will be allowed
+# to remain idle in the connection pool.  Default is 25%
+# of the maximum number of active connections.
+#
 VitroConnection.DataSource.pool.maxIdle = 10
 
-
-# -----------------------------------------------------------------------------
-# USING A DIFFERENT DATA STORE
-# -----------------------------------------------------------------------------
-
-  #
-  # Parameters to change in order to use VIVO with a database other than 
-  # MySQL.
-  #
+#
+# Parameters to change in order to use VIVO with a database other than 
+# MySQL.
+#
 VitroConnection.DataSource.dbtype = MySQL
 VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
 VitroConnection.DataSource.validationQuery = SELECT 1
 
-  #
-  # Optional URI of a SPARQL endpoint from which VIVO should display data. 
-  # If set, VIVO will use this endpoint as its triple store instead of the
-  # SDB database.
-  # 
+#
+# Optional URI of a SPARQL endpoint from which VIVO should display data. 
+# If set, VIVO will use this endpoint as its triple store instead of the
+# SDB database.
+# 
 #VitroConnection.DataSource.endpointURI =
 
-  #
-  # Optional URI to use for modifying the above endpoint via SPARQL UPDATE.
-  # This setting is only necessary if the endpoint does not support updates via
-  # its main URI.  (This may be done for access control purposes.)
-  # If the endpointURI above is not set, this setting has no effect.
-  #
+#
+# Optional URI to use for modifying the above endpoint via SPARQL UPDATE.
+# This setting is only necessary if the endpoint does not support updates via
+# its main URI.  (This may be done for access control purposes.)
+# If the endpointURI above is not set, this setting has no effect.
+#
 #VitroConnection.DataSource.updateEndpointURI =
 
+#
+# The email address of the root user for the VIVO application. The password 
+# for this user is initially set to "rootPassword", but you will be asked to 
+# change the password the first time you log in.
+#
+rootUser.emailAddress = tw-dco@lists.rpi.edu
 
-# -----------------------------------------------------------------------------
-# ADDING OPENSOCIAL GADGETS TO VIVO
-# -----------------------------------------------------------------------------
+#
+# How is a logged-in user associated with a particular Individual? One way is 
+# for the Individual to have a property whose value is the username of the user.
+# This value should be the URI for that property.
+#
+#selfEditing.idMatchingProperty = http://vivoweb.org/ontology/core#primaryEmail
+#selfEditing.idMatchingProperty = http://www.w3.org/2000/01/rdf-schema#label
+selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
 
-  #
-  # For OpenSocial integration
-  # The base URL of the ORNG Shindig server. Usually, this is the same host and port
-  # number as VIVO itself, with a context path of "shindigorng".
-  #
-#OpenSocial.shindigURL = http://localhost:8080/shindigorng 
+#
+# If an external authentication system like Shibboleth or CUWebAuth is to be
+# used, this property says which HTTP header will contain the user ID from 
+# the authentication system. If such a system is not to be used, leave this 
+# commented out. Consult the installation instructions for more details. 
+#
+externalAuth.buttonText = DCO Single Sign On
+externalAuth.netIdHeaderName = uid
 
-  #
-  # For OpenSocial integration
-  # The host name and port number of the service that provides security tokens for VIVO and
-  # Shindig to share. For now, the host name must be the actual host, not "localhost" or "127.0.0.1"
-  # The port number must be 8777 
-  #
-#OpenSocial.tokenService = myhost.mydomain.edu:8777
-
-  #
-  # For OpenSocial integration
-  # The path to the key file that will be used qwhen generating security tokens for VIVO and 
-  # shindig to share.
-  #
-#OpenSocial.tokenKeyFile = /usr/local/vivo/data/shindig/openssl/securitytokenkey.txt
-
-  #
-  # For OpenSocial integration
-  # Only set sandbox to True for dev/test environments.  Comment out or set to False in production
-  #
-#OpenSocial.sandbox = True
-
-
-# -----------------------------------------------------------------------------
-# ADDING LANGUAGES TO VIVO
-# -----------------------------------------------------------------------------
-
-  #
-  # Show only the most appropriate data values based on the Accept-Language 
-  # header supplied by the browser.  Default is false if not set.
-  #
-# RDFService.languageFilter = false
-
-  #
-  # Force VIVO to use a specific language or Locale instead of those 
-  # specified by the browser. This affects RDF data retrieved from the model, 
-  # if RDFService.languageFilter is true. This also affects the text of pages
-  # that have been modified to support multiple languages. 
-  #
-# languages.forceLocale = en_US
-
-  #
-  # A list of supported languages or Locales that the user may choose to
-  # use instead of the one specified by the browser. Selection images must
-  # be available in the i18n/images directory of the theme. This affects 
-  # RDF data retrieved from the model, if RDFService.languageFilter is true.  
-  # This also affects the text of pages that have been modified to support 
-  # multiple languages. 
-  #
-  # This should not be used with languages.forceLocale, which will override it.
-  #
-# languages.selectableLocales = en_US, es_GO
-
-
-# -----------------------------------------------------------------------------
-# OTHER OPTIONS
-# -----------------------------------------------------------------------------
-
-  #  
-  # When the following flag is set to enabled, the VIVO home page displays a 
-  # global map highlighting the geographical focus of foaf:person individuals. 
-  # For information on the maps, refer to this wiki page:
-  # https://wiki.duraspace.org/display/VIVO/Home+Page+Customizations#HomePageCustomizations-TheGeographicFocusMap
-  #
-#homePage.geoFocusMaps=enabled
-
-
-  #  
-  # VIVO supports the simultaneous use of a full foaf:Person profile page view 
-  # and a "quick" page view that emphasizes the individual's webpage presence. 
-  # Implementing this feature requires an installation to develop a web service
-  # that captures images of web pages or to use an existing service outside of VIVO. 
-  # 
-  # For more information on implementing multiple profile pages, refer to this 
-  # wiki page: https://wiki.duraspace.org/display/VIVO/Multiple+foaf%3APerson+Profile+Pages.
-  #
-#multiViews.profilePageTypes=enabled
-
-
-  #
-  # Tell VIVO to generate HTTP headers on its responses to facilitate caching the 
-  # profile pages that it creates. 
-  #
-  # For more information, see this wiki page: 
-  # https://wiki.duraspace.org/display/VIVO/Use+HTTP+caching+to+improve+performance
-  #
-  # Developers will likely want to leave caching disabled, since a change to a
-  # Freemarker template or to a Java class would not cause the page to be 
-  # considered stale.
-  #
-# http.createCacheHeaders = true
-
-  #
-  # Absolute path on the server of the Harvester root directory.
-  # You must include the final slash.
-  #
-  # Setting a value for harvester.location indicates that the Harvester is installed at
-  # this path. This will enable the Harvester functions in the Ingest Tools page.
-  #
-# harvester.location = /usr/local/vivo/harvester/
-
-  #
-  # The temporal graph visualization is used to compare different organizations/people
-  # within an organization on parameters like number of publications or grants.
-  # By default, the app will attempt to make its best guess at the top level
-  # organization in your instance. If you're unhappy with this selection, uncomment out
-  # the property below and set it to the URI of the organization individual you want to
-  # identify as the top level organization. It will be used as the default whenever the
-  # temporal graph visualization is rendered without being passed an explicit org.
-  # For example, to use "Ponce School of Medicine" as the top organization:
-  # visualization.topLevelOrg = http://vivo.psm.edu/individual/n2862
-  #
-# visualization.topLevelOrg = http://vivo.mydomain.edu/individual/topLevelOrgURI
-
-  #  
-  # The temporal graph visualization can require extensive machine resources.
-  # This can have a particularly noticeable impact on memory usage if
-  # - The organization tree is deep,
-  # - The number of grants and publications is large.
-  # VIVO 1.3 release mitigates this problem by the way of a caching mechanism & 
-  # hence we can safely set this to be enabled by default.
-  #
+#
+# The temporal graph visualization can require extensive machine resources.
+# This can have a particularly noticeable impact on memory usage if
+# - The organization tree is deep,
+# - The number of grants and publications is large.
+# VIVO 1.3 release mitigates this problem by the way of a caching mechanism & 
+# hence we can safely set this to be enabled by default.
+#
 visualization.temporal = enabled 
 
-  #
-  # Types of individual for which we can create proxy editors.
-  # If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
-  #
-proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf/0.1/Organization
+#
+# The temporal graph visualization is used to compare different organizations/people
+# within an organization on parameters like number of publications or grants.
+# By default, the app will attempt to make its best guess at the top level
+# organization in your instance. If you're unhappy with this selection, uncomment out
+# the property below and set it to the URI of the organization individual you want to
+# identify as the top level organization. It will be used as the default whenever the
+# temporal graph visualization is rendered without being passed an explicit org.
+# For example, to use "Ponce School of Medicine" as the top organization:
+# visualization.topLevelOrg = http://vivo.psm.edu/individual/n2862
+#
+# visualization.topLevelOrg = http://vivo.mydomain.edu/individual/topLevelOrgURI
 
-  #
-  # Default type(s) for Google Refine Reconciliation Service
-  # The format for this property is id, name; id1, name1; id2, name2 etc.
-  # For more information, see Service Metadata from this page:
-  # http://code.google.com/p/google-refine/wiki/ReconciliationServiceApi
-  # 
+#
+# Absolute path on the server of the Harvester root directory.
+# You must include the final slash.
+# Setting a value for harvester.location indicates that the Harvester is installed at
+# this path. This will enable the Harvester functions in the Ingest Tools page.
+#
+# harvester.location = /usr/local/vivo/harvester/
+
+#
+# Default type(s) for Google Refine Reconciliation Service
+# The format for this property is id, name; id1, name1; id2, name2 etc.
+# See Service Metadata from this page http://code.google.com/p/google-refine/wiki/ReconciliationServiceApi
+# for more information.
 Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Role; \
     http://vivoweb.org/ontology/core#AcademicDegree, core:Academic Degree; \
     http://purl.org/NET/c4dm/event.owl#Event, event:Event; \
@@ -287,3 +153,101 @@ Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Ro
     http://xmlns.com/foaf/0.1/Organization, foaf:Organization; \
     http://xmlns.com/foaf/0.1/Person, foaf:Person; \
     http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030 
+
+#
+# Types of individual for which we can create proxy editors.
+# If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
+#
+proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf/0.1/Organization
+
+#
+# Show only the most appropriate data values based on the Accept-Language 
+# header supplied by the browser.  Default is false if not set.
+#
+# RDFService.languageFilter = false
+
+#
+# Force VIVO to use a specific language or Locale instead of those 
+# specified by the browser. This affects RDF data retrieved from the model, 
+# if RDFService.languageFilter is true. This also affects the text of pages
+# that have been modified to support multiple languages. 
+#
+# languages.forceLocale = en_US
+
+#
+# A list of supported languages or Locales that the user may choose to
+# use instead of the one specified by the browser. Selection images must
+# be available in the i18n/images directory of the theme. This affects 
+# RDF data retrieved from the model, if RDFService.languageFilter is true.  
+# This also affects the text of pages that have been modified to support 
+# multiple languages. 
+#
+# This should not be used with languages.forceLocale, which will override it.
+#
+# languages.selectableLocales = en_US, es_GO
+
+#
+# Tell VIVO to generate HTTP headers on its responses to facilitate caching the 
+# profile pages that it creates. 
+#
+# For more information, see 
+# https://wiki.duraspace.org/display/VIVO/Use+HTTP+caching+to+improve+performance
+#
+# Developers will likely want to leave caching disabled, since a change to a
+# Freemarker template or to a Java class would not cause the page to be 
+# considered stale.
+#
+# http.createCacheHeaders = true
+
+#
+# For OpenSocial integration
+# The base URL of the ORNG Shindig server. Usually, this is the same host and port
+# number as VIVO itself, with a context path of "shindigorng".
+#
+#OpenSocial.shindigURL = http://localhost:8080/shindigorng 
+
+#
+# For OpenSocial integration
+# The host name and port number of the service that provides security tokens for VIVO and
+# Shindig to share. For now, the host name must be the actual host, not "localhost" or "127.0.0.1"
+# The port number must be 8777
+#
+#OpenSocial.tokenService = myhost.mydomain.edu:8777
+
+#
+# For OpenSocial integration
+# The path to the key file that will be used qwhen generating security tokens for VIVO and 
+# shindig to share.
+#
+#OpenSocial.tokenKeyFile = /usr/local/vivo/data/shindig/openssl/securitytokenkey.txt
+
+#
+# For OpenSocial integration
+# Only set sandbox to True for dev/test environments.  Comment out or set to False in production
+#
+#OpenSocial.sandbox = True
+
+# MultiViews 
+# VIVO supports the simultaneous use of a full foaf:Person profile page view and a "quick" page 
+# view that emphasizes the individual's webpage presence. Implementing this feature requires an 
+# installation to develop a web service that captures images of web pages or to use an existing 
+# service outside of VIVO. For more information on implementing multiple profile pages, refer to 
+# this wiki page: https://wiki.duraspace.org/display/VIVO/Multiple+foaf%3APerson+Profile+Pages.
+#multiViews.profilePageTypes=enabled
+
+# Geo Focus Maps 
+# When the following flag is set to enabled, the VIVO home page displays a global map highlighting the 
+# geographical focus of foaf:person individuals. For information on the maps, refer to this wiki page:
+# https://wiki.duraspace.org/display/VIVO/Home+Page+Customizations#HomePageCustomizations-TheGeographicFocusMap
+#homePage.geoFocusMaps=enabled
+
+DCO.baseURL = https://info.deepcarbon.net/vivo
+DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
+DCO.ckanURL = http://data.deepcarbon.net/ckan
+DCO.URI = http://info.deepcarbon.net/schema#
+DCO.rootName = tw-dco@lists.rpi.edu
+DCO.rootPassword = myts-eth-erd
+DCO.endpoint = http://info.deepcarbon.net/endpoint
+DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+

--- a/runtime.properties
+++ b/runtime.properties
@@ -244,10 +244,12 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
 DCO.baseURL = https://info.deepcarbon.net/vivo
 DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
 DCO.ckanURL = http://data.deepcarbon.net/ckan
+DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://info.deepcarbon.net/endpoint
+DCO.endpoint = http://localhost:3030
 DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
 DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/runtime.properties
+++ b/runtime.properties
@@ -248,8 +248,8 @@ DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://localhost:3030
-DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
-DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+DCO.endpoint = http://128.213.3.13:3030
+DCO.sparqlQueryAPI = http://128.213.3.13:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://128.213.3.13:8080/vivo/api/sparqlUpdate
 DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/runtime.properties
+++ b/runtime.properties
@@ -242,14 +242,14 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
 #homePage.geoFocusMaps=enabled
 
 DCO.baseURL = https://info.deepcarbon.net/vivo
-DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
+DCO.handleURL = http://deepcarbon.tw.rpi.edu:8080/dcohandleservice/services/handles/
 DCO.ckanURL = http://data.deepcarbon.net/ckan
-DCO.ckanApiKey = 609500d6-231b-4ab1-becf-e8382d08e5a0
+DCO.ckanApiKey = 96c00a49-9604-42ca-84b1-e43674f6c0f8
 DCO.URI = http://info.deepcarbon.net/schema#
 DCO.rootName = tw-dco@lists.rpi.edu
 DCO.rootPassword = myts-eth-erd
-DCO.endpoint = http://128.213.3.13:3030
-DCO.sparqlQueryAPI = http://128.213.3.13:8080/vivo/admin/sparqlquery
-DCO.sparqlUpdateAPI = http://128.213.3.13:8080/vivo/api/sparqlUpdate
+DCO.endpoint = http://deepcarbon.tw.rpi.edu:3030
+DCO.sparqlQueryAPI = http://deepcarbon.tw.rpi.edu:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://deepcarbon.tw.rpi.edu:8080/vivo/api/sparqlUpdate
 DCO.baseNamespace = http://info.deepcarbon.net/individual/
 

--- a/runtime.properties
+++ b/runtime.properties
@@ -4,311 +4,250 @@
 #
 # This file is provided as example.runtime.properties.
 #
-# Save a copy of this file as runtime.properties in your Vitro home directory,
+# Save a copy of this file as runtime.properties in your Vitro home directory, 
 # and edit the properties as needed for your installation.
 #
 # -----------------------------------------------------------------------------
 
+# 
+# This namespace will be used when generating URIs for objects created in the 
+# editor. In order to serve linked data, the default namespace must be composed 
+# as follows (optional elements in parentheses):
+#
+# scheme + server_name (+ port) (+ servlet_context) + "/individual/"
+# 
+# For example, Cornell's default namespace is:
+#
+# http://vivo.cornell.edu/individual/
+#
+Vitro.defaultNamespace = http://info.deepcarbon.net/individual/
 
-# -----------------------------------------------------------------------------
-# BASIC PROPERTIES
-# -----------------------------------------------------------------------------
+# 
+# URL of Solr context used in local VIVO search. This will usually consist of:
+#     scheme + server_name + port + vivo_webapp_name + "solr"
+# In the standard installation, the Solr context will be on the same server as VIVO,
+# and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
+# above) + "solr"
+#   Example:
+#     vitro.local.solr.url = http://localhost:8080/vivosolr
+vitro.local.solr.url = http://128.213.3.13:8080/vivosolr
 
-  #
-  # This namespace will be used when generating URIs for objects created in the
-  # editor. In order to serve linked data, the default namespace must be composed
-  # as follows (optional elements in parentheses):
-  #
-  # scheme + server_name (+ port) (+ servlet_context) + "/individual/"
-  #
-  # For example, Cornell's default namespace is:
-  #
-  # http://vivo.cornell.edu/individual/
-  #
-Vitro.defaultNamespace = http://data.tw.rpi.edu/info/individual/
+#
+# Email parameters which VIVO can use to send mail. If these are left empty, 
+# the "Contact Us" form will be disabled and users will not be notified of
+# changes to their accounts.
+#
+#email.smtpHost = smtp.mydomain.edu
+#email.replyTo = vivoAdmin@mydomain.edu
 
-  #
-  # The email address of the root user for the VIVO application. The password
-  # for this user is initially set to "rootPassword", but you will be asked to
-  # change the password the first time you log in.
-  #
-rootUser.emailAddress = westp@rpi.edu
+#
+# The basic parameters for a database connection. Change the end of the 
+# URL to reflect your database name (if it is not "vitrodb"). Change the username 
+# and password to match the authorized database user you created.
+#
+VitroConnection.DataSource.url = jdbc:mysql://localhost/vivo
+VitroConnection.DataSource.username = vivo
+VitroConnection.DataSource.password = vivo
 
-  #
-  # The basic parameters for a database connection. Change the end of the
-  # URL to reflect your database name (if it is not "vitrodb"). Change the username
-  # and password to match the authorized database user you created.
-  #
-VitroConnection.DataSource.url = jdbc:mysql://localhost/vivodb
-VitroConnection.DataSource.username = vivo_user
-VitroConnection.DataSource.password = vivo_password
-
-  #
-  # Email parameters which VIVO can use to send mail. If these are left empty,
-  # the "Contact Us" form will be disabled and users will not be notified of
-  # changes to their accounts.
-  #
-email.smtpHost = mail.rpi.edu
-email.replyTo =westp@rpi.edu
-
-  #
-  # URL of Solr context used in local VIVO search. This will usually consist of:
-  #     scheme + server_name + port + vivo_webapp_name + "solr"
-  # In the standard installation, the Solr context will be on the same server as VIVO,
-  # and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
-  # above) + "solr"
-  #   Example:
-  #     vitro.local.solr.url = http://localhost:8080/vivosolr
-  #
-vitro.local.solr.url = http://localhost:8080/vivosolr
-
-
-# -----------------------------------------------------------------------------
-# LINKING USER ACCOUNTS TO PROFILE PAGES
-# -----------------------------------------------------------------------------
-
-  #
-  # How is a logged-in user associated with a particular Individual? One way is
-  # for the Individual to have a property whose value is the username of the user.
-  # This value should be the URI for that property.
-  #
-selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
-
-
-# -----------------------------------------------------------------------------
-# USING AN EXTERNAL AUTHENTICATION SYSTEM
-# -----------------------------------------------------------------------------
-
-  #
-  # If an external authentication system like Shibboleth or CUWebAuth is to be
-  # used, this property says which HTTP header will contain the user ID from
-  # the authentication system. If such a system is not to be used, leave this
-  # commented out. Consult the installation instructions for more details.
-  #
-#externalAuth.netIdHeaderName = remote_userID
-
-
-# -----------------------------------------------------------------------------
-# TUNING THE DATABASE CONNECTION POOL
-# -----------------------------------------------------------------------------
-
-  #
-  # The maximum number of active connections in the database connection pool.
-  # Increase this value to support a greater number of concurrent page requests.
-  #
+#
+# The maximum number of active connections in the database connection pool.
+# Increase this value to support a greater number of concurrent page requests.
+#
 VitroConnection.DataSource.pool.maxActive = 40
 
-  #
-  # The maximum number of database connections that will be allowed
-  # to remain idle in the connection pool.  Default is 25%
-  # of the maximum number of active connections.
-  #
+#
+# The maximum number of database connections that will be allowed
+# to remain idle in the connection pool.  Default is 25%
+# of the maximum number of active connections.
+#
 VitroConnection.DataSource.pool.maxIdle = 10
 
-
-# -----------------------------------------------------------------------------
-# USING A DIFFERENT DATA STORE
-# -----------------------------------------------------------------------------
-
-  #
-  # Parameters to change in order to use VIVO with a database other than
-  # MySQL.
-  #
+#
+# Parameters to change in order to use VIVO with a database other than 
+# MySQL.
+#
 VitroConnection.DataSource.dbtype = MySQL
 VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
 VitroConnection.DataSource.validationQuery = SELECT 1
 
-  #
-  # Optional URI of a SPARQL endpoint from which VIVO should display data.
-  # If set, VIVO will use this endpoint as its triple store instead of the
-  # SDB database.
-  #
+#
+# Optional URI of a SPARQL endpoint from which VIVO should display data. 
+# If set, VIVO will use this endpoint as its triple store instead of the
+# SDB database.
+# 
 #VitroConnection.DataSource.endpointURI =
 
-  #
-  # Optional URI to use for modifying the above endpoint via SPARQL UPDATE.
-  # This setting is only necessary if the endpoint does not support updates via
-  # its main URI.  (This may be done for access control purposes.)
-  # If the endpointURI above is not set, this setting has no effect.
-  #
+#
+# Optional URI to use for modifying the above endpoint via SPARQL UPDATE.
+# This setting is only necessary if the endpoint does not support updates via
+# its main URI.  (This may be done for access control purposes.)
+# If the endpointURI above is not set, this setting has no effect.
+#
 #VitroConnection.DataSource.updateEndpointURI =
 
+#
+# The email address of the root user for the VIVO application. The password 
+# for this user is initially set to "rootPassword", but you will be asked to 
+# change the password the first time you log in.
+#
+rootUser.emailAddress = tw-dco@lists.rpi.edu
 
-# -----------------------------------------------------------------------------
-# ADDING OPENSOCIAL GADGETS TO VIVO
-# -----------------------------------------------------------------------------
+#
+# How is a logged-in user associated with a particular Individual? One way is 
+# for the Individual to have a property whose value is the username of the user.
+# This value should be the URI for that property.
+#
+#selfEditing.idMatchingProperty = http://vivoweb.org/ontology/core#primaryEmail
+#selfEditing.idMatchingProperty = http://www.w3.org/2000/01/rdf-schema#label
+selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
 
-  #
-  # For OpenSocial integration
-  # The base URL of the ORNG Shindig server. Usually, this is the same host and port
-  # number as VIVO itself, with a context path of "shindigorng".
-  #
-#OpenSocial.shindigURL = http://localhost:8080/shindigorng
+#
+# If an external authentication system like Shibboleth or CUWebAuth is to be
+# used, this property says which HTTP header will contain the user ID from 
+# the authentication system. If such a system is not to be used, leave this 
+# commented out. Consult the installation instructions for more details. 
+#
+externalAuth.buttonText = DCO Single Sign On
+externalAuth.netIdHeaderName = uid
 
-  #
-  # For OpenSocial integration
-  # The host name and port number of the service that provides security tokens for VIVO and
-  # Shindig to share. For now, the host name must be the actual host, not "localhost" or "127.0.0.1"
-  # The port number must be 8777
-  #
-#OpenSocial.tokenService = myhost.mydomain.edu:8777
+#
+# The temporal graph visualization can require extensive machine resources.
+# This can have a particularly noticeable impact on memory usage if
+# - The organization tree is deep,
+# - The number of grants and publications is large.
+# VIVO 1.3 release mitigates this problem by the way of a caching mechanism & 
+# hence we can safely set this to be enabled by default.
+#
+visualization.temporal = enabled 
 
-  #
-  # For OpenSocial integration
-  # The path to the key file that will be used qwhen generating security tokens for VIVO and
-  # shindig to share.
-  #
-#OpenSocial.tokenKeyFile = /usr/local/vivo/data/shindig/openssl/securitytokenkey.txt
-
-  #
-  # For OpenSocial integration
-  # Only set sandbox to True for dev/test environments.  Comment out or set to False in production
-  #
-#OpenSocial.sandbox = True
-
-
-# -----------------------------------------------------------------------------
-# ADDING LANGUAGES TO VIVO
-# -----------------------------------------------------------------------------
-
-  #
-  # Show only the most appropriate data values based on the Accept-Language
-  # header supplied by the browser.  Default is false if not set.
-  #
-# RDFService.languageFilter = false
-
-  #
-  # Force VIVO to use a specific language or Locale instead of those
-  # specified by the browser. This affects RDF data retrieved from the model,
-  # if RDFService.languageFilter is true. This also affects the text of pages
-  # that have been modified to support multiple languages.
-  #
-# languages.forceLocale = en_US
-
-  #
-  # A list of supported languages or Locales that the user may choose to
-  # use instead of the one specified by the browser. Selection images must
-  # be available in the i18n/images directory of the theme. This affects
-  # RDF data retrieved from the model, if RDFService.languageFilter is true.
-  # This also affects the text of pages that have been modified to support
-  # multiple languages.
-  #
-  # This should not be used with languages.forceLocale, which will override it.
-  #
-# languages.selectableLocales = en_US, es_GO
-
-
-# -----------------------------------------------------------------------------
-# ORCID INTEGRATION
-# -----------------------------------------------------------------------------
-
-# orcid.clientId = 0000-0000-0000-000X
-# orcid.clientPassword = 00000000-0000-0000-0000-000000000000
-# orcid.webappBaseUrl = http://localhost:8080/vivo
-# orcid.messageVersion = 1.0.23
-# orcid.externalIdCommonName = VIVO Cornell Identifier
-
-# ---- Setup for the sandbox ----
-
-# orcid.publicApiBaseUrl     = http://pub.sandbox.orcid.org/v1.1
-# orcid.authorizedApiBaseUrl = http://api.sandbox.orcid.org/v1.1
-# orcid.oauthAuthorizeUrl    = http://sandbox.orcid.org/oauth/authorize
-# orcid.oauthTokenUrl        = http://api.sandbox.orcid.org/oauth/token
-
-# ---- or for the mockorcid webapp ----
-
-# orcid.publicApiBaseUrl     = http://localhost:8080/mockorcid/mock/
-# orcid.authorizedApiBaseUrl = http://localhost:8080/mockorcid/mock/
-# orcid.oauthAuthorizeUrl    = http://localhost:8080/mockorcid/mock/oauth/authorize
-# orcid.oauthTokenUrl        = http://localhost:8080/mockorcid/mock/oauth/token
-
-
-# -----------------------------------------------------------------------------
-# OTHER OPTIONS
-# -----------------------------------------------------------------------------
-
-  #
-  # When the following flag is set to enabled, the VIVO home page displays a
-  # global map highlighting the geographical focus of foaf:person individuals.
-  # For information on the maps, refer to this wiki page:
-  # https://wiki.duraspace.org/display/VIVO/Home+Page+Customizations#HomePageCustomizations-TheGeographicFocusMap
-  #
-homePage.geoFocusMaps=enabled
-
-
-  #
-  # VIVO supports the simultaneous use of a full foaf:Person profile page view
-  # and a "quick" page view that emphasizes the individual's webpage presence.
-  # Implementing this feature requires an installation to develop a web service
-  # that captures images of web pages or to use an existing service outside of VIVO.
-  #
-  # For more information on implementing multiple profile pages, refer to this
-  # wiki page: https://wiki.duraspace.org/display/VIVO/Multiple+foaf%3APerson+Profile+Pages.
-  #
-#multiViews.profilePageTypes=enabled
-
-
-  #
-  # Tell VIVO to generate HTTP headers on its responses to facilitate caching the
-  # profile pages that it creates.
-  #
-  # For more information, see this wiki page:
-  # https://wiki.duraspace.org/display/VIVO/Use+HTTP+caching+to+improve+performance
-  #
-  # Developers will likely want to leave caching disabled, since a change to a
-  # Freemarker template or to a Java class would not cause the page to be
-  # considered stale.
-  #
-# http.createCacheHeaders = true
-
-  #
-  # Absolute path on the server of the Harvester root directory.
-  # You must include the final slash.
-  #
-  # Setting a value for harvester.location indicates that the Harvester is installed at
-  # this path. This will enable the Harvester functions in the Ingest Tools page.
-  #
-# harvester.location = /usr/local/vivo/harvester/
-
-  #
-  # The temporal graph visualization is used to compare different organizations/people
-  # within an organization on parameters like number of publications or grants.
-  # By default, the app will attempt to make its best guess at the top level
-  # organization in your instance. If you're unhappy with this selection, uncomment out
-  # the property below and set it to the URI of the organization individual you want to
-  # identify as the top level organization. It will be used as the default whenever the
-  # temporal graph visualization is rendered without being passed an explicit org.
-  # For example, to use "Ponce School of Medicine" as the top organization:
-  # visualization.topLevelOrg = http://vivo.psm.edu/individual/n2862
-  #
+#
+# The temporal graph visualization is used to compare different organizations/people
+# within an organization on parameters like number of publications or grants.
+# By default, the app will attempt to make its best guess at the top level
+# organization in your instance. If you're unhappy with this selection, uncomment out
+# the property below and set it to the URI of the organization individual you want to
+# identify as the top level organization. It will be used as the default whenever the
+# temporal graph visualization is rendered without being passed an explicit org.
+# For example, to use "Ponce School of Medicine" as the top organization:
+# visualization.topLevelOrg = http://vivo.psm.edu/individual/n2862
+#
 # visualization.topLevelOrg = http://vivo.mydomain.edu/individual/topLevelOrgURI
 
-  #
-  # The temporal graph visualization can require extensive machine resources.
-  # This can have a particularly noticeable impact on memory usage if
-  # - The organization tree is deep,
-  # - The number of grants and publications is large.
-  # VIVO 1.3 release mitigates this problem by the way of a caching mechanism &
-  # hence we can safely set this to be enabled by default.
-  #
-visualization.temporal = enabled
+#
+# Absolute path on the server of the Harvester root directory.
+# You must include the final slash.
+# Setting a value for harvester.location indicates that the Harvester is installed at
+# this path. This will enable the Harvester functions in the Ingest Tools page.
+#
+# harvester.location = /usr/local/vivo/harvester/
 
-  #
-  # Types of individual for which we can create proxy editors.
-  # If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
-  #
-proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf/0.1/Organization
-
-  #
-  # Default type(s) for Google Refine Reconciliation Service
-  # The format for this property is id, name; id1, name1; id2, name2 etc.
-  # For more information, see Service Metadata from this page:
-  # http://code.google.com/p/google-refine/wiki/ReconciliationServiceApi
-  #
+#
+# Default type(s) for Google Refine Reconciliation Service
+# The format for this property is id, name; id1, name1; id2, name2 etc.
+# See Service Metadata from this page http://code.google.com/p/google-refine/wiki/ReconciliationServiceApi
+# for more information.
 Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Role; \
     http://vivoweb.org/ontology/core#AcademicDegree, core:Academic Degree; \
     http://purl.org/NET/c4dm/event.owl#Event, event:Event; \
     http://vivoweb.org/ontology/core#Location, core:Location; \
     http://xmlns.com/foaf/0.1/Organization, foaf:Organization; \
     http://xmlns.com/foaf/0.1/Person, foaf:Person; \
-    http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030
+    http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030 
+
+#
+# Types of individual for which we can create proxy editors.
+# If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
+#
+proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf/0.1/Organization
+
+#
+# Show only the most appropriate data values based on the Accept-Language 
+# header supplied by the browser.  Default is false if not set.
+#
+# RDFService.languageFilter = false
+
+#
+# Force VIVO to use a specific language or Locale instead of those 
+# specified by the browser. This affects RDF data retrieved from the model, 
+# if RDFService.languageFilter is true. This also affects the text of pages
+# that have been modified to support multiple languages. 
+#
+# languages.forceLocale = en_US
+
+#
+# A list of supported languages or Locales that the user may choose to
+# use instead of the one specified by the browser. Selection images must
+# be available in the i18n/images directory of the theme. This affects 
+# RDF data retrieved from the model, if RDFService.languageFilter is true.  
+# This also affects the text of pages that have been modified to support 
+# multiple languages. 
+#
+# This should not be used with languages.forceLocale, which will override it.
+#
+# languages.selectableLocales = en_US, es_GO
+
+#
+# Tell VIVO to generate HTTP headers on its responses to facilitate caching the 
+# profile pages that it creates. 
+#
+# For more information, see 
+# https://wiki.duraspace.org/display/VIVO/Use+HTTP+caching+to+improve+performance
+#
+# Developers will likely want to leave caching disabled, since a change to a
+# Freemarker template or to a Java class would not cause the page to be 
+# considered stale.
+#
+# http.createCacheHeaders = true
+
+#
+# For OpenSocial integration
+# The base URL of the ORNG Shindig server. Usually, this is the same host and port
+# number as VIVO itself, with a context path of "shindigorng".
+#
+#OpenSocial.shindigURL = http://localhost:8080/shindigorng 
+
+#
+# For OpenSocial integration
+# The host name and port number of the service that provides security tokens for VIVO and
+# Shindig to share. For now, the host name must be the actual host, not "localhost" or "127.0.0.1"
+# The port number must be 8777
+#
+#OpenSocial.tokenService = myhost.mydomain.edu:8777
+
+#
+# For OpenSocial integration
+# The path to the key file that will be used qwhen generating security tokens for VIVO and 
+# shindig to share.
+#
+#OpenSocial.tokenKeyFile = /usr/local/vivo/data/shindig/openssl/securitytokenkey.txt
+
+#
+# For OpenSocial integration
+# Only set sandbox to True for dev/test environments.  Comment out or set to False in production
+#
+#OpenSocial.sandbox = True
+
+# MultiViews 
+# VIVO supports the simultaneous use of a full foaf:Person profile page view and a "quick" page 
+# view that emphasizes the individual's webpage presence. Implementing this feature requires an 
+# installation to develop a web service that captures images of web pages or to use an existing 
+# service outside of VIVO. For more information on implementing multiple profile pages, refer to 
+# this wiki page: https://wiki.duraspace.org/display/VIVO/Multiple+foaf%3APerson+Profile+Pages.
+#multiViews.profilePageTypes=enabled
+
+# Geo Focus Maps 
+# When the following flag is set to enabled, the VIVO home page displays a global map highlighting the 
+# geographical focus of foaf:person individuals. For information on the maps, refer to this wiki page:
+# https://wiki.duraspace.org/display/VIVO/Home+Page+Customizations#HomePageCustomizations-TheGeographicFocusMap
+#homePage.geoFocusMaps=enabled
+
+DCO.baseURL = https://info.deepcarbon.net/vivo
+DCO.handleURL = http://128.213.3.13:8080/dcohandleservice/services/handles/
+DCO.ckanURL = http://data.deepcarbon.net/ckan
+DCO.URI = http://info.deepcarbon.net/schema#
+DCO.rootName = tw-dco@lists.rpi.edu
+DCO.rootPassword = myts-eth-erd
+DCO.endpoint = http://info.deepcarbon.net/endpoint
+DCO.sparqlQueryAPI = http://localhost:8080/vivo/admin/sparqlquery
+DCO.sparqlUpdateAPI = http://localhost:8080/vivo/api/sparqlUpdate
+

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddDistributionDatasetController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddDistributionDatasetController.java
@@ -107,7 +107,7 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 
 		ServletContext ctx = req.getSession().getServletContext();
 		String dcoNamespace = ServerInfo.getInstance().getDefaultNamespace( ctx ) ;
-		String baseURL = ServerInfo.getInstance().getBaseURL( ctx );
+		String baseNamespace = ServerInfo.getInstance().getBaseNamespace( ctx );
 
     	boolean isMultipart = ServletFileUpload.isMultipartContent(req);
     	CkanMultipartHttpServletRequest depositRequest = null;
@@ -192,7 +192,7 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 			e.printStackTrace();
 		}
 		
-		configuration.setUrlToReturnTo(configuration.getUrlToReturnTo().replace(dcoNamespace, baseURL));
+		configuration.setUrlToReturnTo(configuration.getUrlToReturnTo().replace(dcoNamespace, baseNamespace));
 		return configuration.getUrlToReturnTo();
 		
     }
@@ -206,7 +206,6 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 
 		try {
 			entityToReturnTo = this.processPost(vreq);	
-			//System.out.println("The return url is "+entityToReturnTo);
 		} catch (ServletException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddDistributionDatasetController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddDistributionDatasetController.java
@@ -33,6 +33,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
@@ -77,10 +78,6 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
     
     private static final long serialVersionUID = 1L;
     private String redirectSubjectUrl = "";
-    private String dcoNamespace = ServerInfo.getInstance().getDcoNamespace();
-    private String dcoOntNamespace = ServerInfo.getInstance().getDcoOntoNamespace();
-    private String absoluteMachineURL = ServerInfo.getInstance().getAbsoluteMachineURL();
-    private String machineURL = ServerInfo.getInstance().getMachineURL();
     /** Limit file size to 6 megabytes. */
 	public static final int MAXIMUM_FILE_SIZE = 6 * 1024 * 1024;
     
@@ -107,7 +104,11 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 			System.out.println(paraName+":"+req.getParameter(paraName));
 		}		
 		*/
-    	
+
+		ServletContext ctx = req.getSession().getServletContext();
+		String dcoNamespace = ServerInfo.getInstance().getDefaultNamespace( ctx ) ;
+		String baseURL = ServerInfo.getInstance().getBaseURL( ctx );
+
     	boolean isMultipart = ServletFileUpload.isMultipartContent(req);
     	CkanMultipartHttpServletRequest depositRequest = null;
     	
@@ -140,6 +141,8 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 	    String key = "<"+configuration.getSubjectUri()+">";
 	    
 	    String actualDownloadURL = depositRequest.getUploadAddr();
+
+		String dcoOntNamespace = ServerInfo.getInstance().getDCOURI( ctx );
 	    
 		dcoidN3Optional = key + " <"+dcoOntNamespace+"hasFile> ?newIndividual .";
 		String instanceInverseStatement = "?newIndividual <"+dcoOntNamespace+"fileFor> "+key+" .";
@@ -147,7 +150,7 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 		//a dco:File, therefore we need to create and object, with data properties of dcoid,label and url.
 		DCOId dcoid = new DCOId();
 		// Go generate the new dco id
-		dcoid.generateDCOId();
+		dcoid.generateDCOId( ctx );
 		String newDcoId = dcoid.getDCOId();
 		String instanceStatement = " ?newIndividual a <"+dcoOntNamespace+"File> .";
 		String instanceDcoidStatment = " ?newIndividual <"+dcoOntNamespace+"dcoId> \""+newDcoId+"\" .";
@@ -173,7 +176,7 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 			String individualURI = submission.getNewIndividualURI().get("newIndividual");
 			//http://deepcarbon.net/vivo/individual/n6739
 			String registeredURI = dcoNamespace + "/individual?uri=" + individualURI;
-			dcoid.operate(registeredURI, "URL", "modifyurl");
+			dcoid.modifyDCOId(registeredURI, ctx);
 			//System.out.println("DCOID generated;Process RDFS:\r\n"+changes.toString());
 			N3EditUtils.preprocessModels(changes, configuration, vreq);		
 			//System.out.println("Apply changes to model\r\n");
@@ -189,7 +192,7 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
 			e.printStackTrace();
 		}
 		
-		configuration.setUrlToReturnTo(configuration.getUrlToReturnTo().replace(dcoNamespace, machineURL));
+		configuration.setUrlToReturnTo(configuration.getUrlToReturnTo().replace(dcoNamespace, baseURL));
 		return configuration.getUrlToReturnTo();
 		
     }
@@ -198,8 +201,9 @@ public class AddDistributionDatasetController extends FreemarkerHttpServlet{
     @Override
 	public ResponseValues processRequest(VitroRequest vreq) {
     	
-    	String entityToReturnTo = absoluteMachineURL;
-    	
+    	ServletContext ctx = vreq.getSession().getServletContext();
+		String entityToReturnTo = ServerInfo.getInstance().getBaseURL( ctx ) ;
+
 		try {
 			entityToReturnTo = this.processPost(vreq);	
 			//System.out.println("The return url is "+entityToReturnTo);

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddPublicationUsingDOIStepTwoController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/AddPublicationUsingDOIStepTwoController.java
@@ -36,6 +36,8 @@ public class AddPublicationUsingDOIStepTwoController extends FreemarkerHttpServl
 
 		ServletContext ctx = vreq.getSession().getServletContext();
 		returnURL = ServerInfo.getInstance().getBaseURL( ctx );
+        String defaultNamespace = ServerInfo.getInstance().getDefaultNamespace( ctx ) ;
+        String baseNamespace = ServerInfo.getInstance().getBaseNamespace( ctx ) ;
 
 		// Check if the publication with the given DOI is already in the system.
 		String doi = vreq.getParameter("doi");
@@ -87,7 +89,7 @@ public class AddPublicationUsingDOIStepTwoController extends FreemarkerHttpServl
 				//System.out.println("VIVO insert request response code:" + vivoInsertRequestStatusCode);		
 				//System.out.println("Insert done!");
 				
-				return new RedirectResponseValues(returnURL);
+				return new RedirectResponseValues(returnURL.replace(defaultNamespace,baseNamespace));
 			} catch (Throwable th) {
 				HashMap<String,Object> map = new HashMap<String,Object>();
 		       	map.put("errorMessage", th.toString());

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/CkanMultipartHttpServletRequest.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/CkanMultipartHttpServletRequest.java
@@ -206,7 +206,7 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 	
 	public String sparqlForAccessURL(String subjectUrl, ServletContext ctx){
 		
-		String endpoint = "https://info.deepcarbon.net/vivo/admin/sparqlquery?query=";
+        String endpoint = ServerInfo.getInstance().getSparqlQueryAPI( ctx );
 		String individualName = subjectUrl;
 		String queryInString = 
 		        "PREFIX dco: <"+ServerInfo.getInstance().getDCOURI(ctx)+">  "+
@@ -222,7 +222,7 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 			e1.printStackTrace();
 		}
 		String queryParams = "&resultFormat=vitro%3Acsv&rdfResultFormat=RDF%2FXML";
-		String url = endpoint+encodedQuery+queryParams;
+		String url = endpoint+"?query="+encodedQuery+queryParams;
 		
 		System.out.println("Request URL is\r\n"+url);
 		

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/CkanMultipartHttpServletRequest.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/CkanMultipartHttpServletRequest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletContext;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
@@ -75,7 +76,6 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 	private final VitroRequest vreq;
 	private final EditConfigurationVTwo configuration;
 	private FileUploadException fileUploadException;
-	private String ckanURL = ServerInfo.getInstance().getCkanURL();
 	
 	/**
 	 * Parse the multipart request. Store the info about the request parameters
@@ -84,6 +84,10 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 	public CkanMultipartHttpServletRequest(HttpServletRequest request,
 			int maxFileSize) throws IOException {
 		super(request);		
+
+        ServletContext ctx = request.getSession().getServletContext();
+        String ckanURL = ServerInfo.getInstance().getCkanURL(ctx);
+
 		Map<String, List<String>> parameters = new HashMap<String, List<String>>();
 		Map<String, List<FileItem>> files = new HashMap<String, List<FileItem>>();
 		CKANAPI myCkanApi = new CKANAPI();
@@ -174,14 +178,14 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 		//Now try to send a sparql request to the endpoint to get back the access url for the dataset, for a single individual
 		//Get the subjectUri
 		String querySubject = configuration.getSubjectUri();
-		String accessURL = this.sparqlForAccessURL(querySubject);
+		String accessURL = this.sparqlForAccessURL(querySubject, ctx);
 		remoteUrl = request.getParameter("remote_url");
 		if(remoteUrl.length()==0){
 			//Deposit to CKAN and get back the download url
 			webFileName = this.files.get("file").get(0).getName();
 			this.fileName = request.getParameter("file-name");
 			System.out.println("File name:\r\n"+webFileName);
-			uploadAddr = myCkanApi.upload_rawdata(this.files.get("file").get(0).getInputStream(),webFileName);
+			uploadAddr = myCkanApi.upload_rawdata(this.files.get("file").get(0).getInputStream(),webFileName, ctx);
 			System.out.println("The uploaded file address is "+uploadAddr);
 		}else{
 			//Not uploading the file; just create a triple, push to the triple store, and store the link here
@@ -193,19 +197,19 @@ class CkanMultipartHttpServletRequest extends FileUploadServletRequest {
 		//Otherwise, do nothing
 		if(accessURL.contains(ckanURL)){
 			if(webFileName.length()>0 )
-				myCkanApi.associateRepoWithDataset(accessURL, uploadAddr, fileName);		
+				myCkanApi.associateRepoWithDataset(accessURL, uploadAddr, fileName, ctx);		
 			else
-				myCkanApi.associateRepoWithDataset(accessURL, uploadAddr, "default-dataset-name");
+				myCkanApi.associateRepoWithDataset(accessURL, uploadAddr, "default-dataset-name", ctx);
 		}
 		
 	}
 	
-	public String sparqlForAccessURL(String subjectUrl){
+	public String sparqlForAccessURL(String subjectUrl, ServletContext ctx){
 		
 		String endpoint = "https://info.deepcarbon.net/vivo/admin/sparqlquery?query=";
 		String individualName = subjectUrl;
 		String queryInString = 
-		        "PREFIX dco: <"+ServerInfo.getInstance().getDcoOntoNamespace()+">  "+
+		        "PREFIX dco: <"+ServerInfo.getInstance().getDCOURI(ctx)+">  "+
 		        "select ?accessAddr "+
 		        "where { "+
 		         "<"+individualName+"> dco:accessURL ?accessAddr .  "+

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DatasetDistributionFileUploadRequest.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DatasetDistributionFileUploadRequest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.Map.Entry;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletContext;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
@@ -90,7 +91,6 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 	private final VitroRequest vreq;
 	private final EditConfigurationVTwo configuration;
 	private FileUploadException fileUploadException;
-	private String ckanURL = ServerInfo.getInstance().getCkanURL();
 	
 	/**
 	 * Parse the multipart request. Store the info about the request parameters
@@ -99,6 +99,10 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 	public DatasetDistributionFileUploadRequest(HttpServletRequest request,
 			int maxFileSize) throws IOException {
 		super(request);		
+
+        ServletContext ctx = request.getSession().getServletContext() ;
+        String ckanURL = ServerInfo.getInstance().getCkanURL(ctx);
+
 		Map<String, List<String>> parameters = new HashMap<String, List<String>>();
 		Map<String, List<FileItem>> files = new HashMap<String, List<FileItem>>();
 		CKANAPI myCkanApi = new CKANAPI();
@@ -140,7 +144,7 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 			List<FileItem> uploadedFiles = this.files.get("file");
 			for(int i = 0; i<uploadedFiles.size(); i++){
 				fileNames.add(uploadedFiles.get(i).getName());
-				uploadAddr = myCkanApi.upload_rawdata(uploadedFiles.get(i).getInputStream(),uploadedFiles.get(i).getName());
+				uploadAddr = myCkanApi.upload_rawdata(uploadedFiles.get(i).getInputStream(),uploadedFiles.get(i).getName(), ctx);
 				uploadFileAddresses.add(uploadAddr);
 			}
 			
@@ -167,13 +171,13 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 			if(webFileName.length()>1 ){
 				System.out.println("For the raw files...");
 				for(int i = 0; i<fileNames.size(); i++){
-					myCkanApi.associateRepoWithDataset(accessAddr, uploadFileAddresses.get(i), fileNames.get(i));		
+					myCkanApi.associateRepoWithDataset(accessAddr, uploadFileAddresses.get(i), fileNames.get(i), ctx);		
 				}
 			}
 			else{
 				System.out.println("For the link files...");
 				System.out.println("!!!\r\n"+uploadAddr+" at "+uploadAddr.lastIndexOf('/'));
-				myCkanApi.associateRepoWithDataset(accessAddr, uploadAddr, uploadAddr.substring(uploadAddr.lastIndexOf('/')+1));
+				myCkanApi.associateRepoWithDataset(accessAddr, uploadAddr, uploadAddr.substring(uploadAddr.lastIndexOf('/')+1), ctx);
 			}
 		}
 		
@@ -189,7 +193,6 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 			System.out.println("Try with instance");
 			ServerInfo.getInstance();
 			System.out.println("Try with attribute");
-			ServerInfo.getInstance().getCkanURL();
 			Client c = new Client( new Connection(ckanURL, apiKey,true),apiKey);
 	        
 	        Dataset ds = new Dataset();
@@ -215,60 +218,6 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 	   		return repoURL;
 	   	}
 	
-	public String sparqlForAccessURL(String subjectUrl){
-		
-		String endpoint = "http://info.deepcarbon.net/vivo/admin/sparqlquery?query=";
-		String individualName = subjectUrl;
-		String queryInString = 
-		        "PREFIX dco: <"+ServerInfo.getInstance().getDcoOntoNamespace()+">  "+
-		        "select ?accessAddr "+
-		        "where { "+
-		         "<"+individualName+"> dco:accessURL ?accessAddr .  "+
-		        "} \n ";
-		String encodedQuery = "";
-		try {
-			encodedQuery = URIUtil.encodeQuery(queryInString);
-		} catch (URIException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
-		}
-		String queryParams = "&resultFormat=vitro%3Acsv&rdfResultFormat=RDF%2FXML";
-		String url = endpoint+encodedQuery+queryParams;
-		
-		System.out.println("Request URL is\r\n"+url);
-		
-		HttpClient client = new DefaultHttpClient();
-		HttpGet request = new HttpGet(url);
-		
-		String accessURL = "";
-		
-		// add request header
-		request.addHeader("User-Agent", "Mozilla/5.0");
-		HttpResponse response;
-		try {
-			response = client.execute(request);
-			
-			BufferedReader rd = new BufferedReader(
-				new InputStreamReader(response.getEntity().getContent()));
-		 
-			StringBuffer result = new StringBuffer();
-			String line = "";
-			while ((line = rd.readLine()) != null) {
-				result.append(line);
-			}
-			System.out.println("query result is:\r\n"+result.toString());
-			accessURL = result.toString().split("accessAddr")[1];
-		} catch (ClientProtocolException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		
-		return accessURL;
-	}
-
 	public String getDatasetName(){
 		return this.datasetName;
 	}

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DatasetDistributionFileUploadRequest.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DatasetDistributionFileUploadRequest.java
@@ -102,6 +102,7 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 
         ServletContext ctx = request.getSession().getServletContext() ;
         String ckanURL = ServerInfo.getInstance().getCkanURL(ctx);
+        String ckanApiKey = ServerInfo.getInstance().getCkanApiKey(ctx);
 
 		Map<String, List<String>> parameters = new HashMap<String, List<String>>();
 		Map<String, List<FileItem>> files = new HashMap<String, List<FileItem>>();
@@ -163,7 +164,7 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 		Date date = new Date();
 		this.distributionName = dateFormat.format(date);
 		   
-		accessAddr = createCkanRepo(distributionName,ckanURL);
+		accessAddr = createCkanRepo(distributionName,ckanURL,ckanApiKey);
 
 		//Only tries to associate the downloadURL with accessURL if it is to the CKAN repo
 		//Otherwise, do nothing
@@ -183,11 +184,10 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 		
 	}
 	
-	public String createCkanRepo(String repoName,String ckanURL){
+	public String createCkanRepo(String repoName,String ckanURL, String apiKey){
 	   	//System.out.println("The name for the object is "+(submission.getLiteralsFromForm().get("label").toString().split("\\[")[1].split("\\^\\^")[0]));
 			String dataRepoName = repoName;
 			
-			String apiKey = "89c2d25c-4ea3-44b4-9fc5-a1f7367fee92";
 			//This is a distribution instance, create a corresponded ckan instance with the name of the distribution
 			System.out.println("Just check ckanURL is:\r\n"+ckanURL);
 			System.out.println("Try with instance");
@@ -206,7 +206,6 @@ class DatasetDistributionFileUploadRequest extends FileUploadServletRequest {
 	        
 	        String repoURL = "";
 	        try {
-	        	
 				Dataset result = c.createDataset(ds);
 				System.out.println("Here is everything "+ckanURL+"/dataset/"+result.getName());
 				repoURL = ckanURL+"/dataset/"+result.getName();

--- a/src/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
@@ -67,9 +67,6 @@ class IndividualResponseBuilder {
 	private final ExecuteDataRetrieval eDataRetrieval;
 
 	private final Individual individual;
-	private static String dcoOntoNamespace = ServerInfo.getInstance().getDcoOntoNamespace();
-	private static String predicateDcoID = dcoOntoNamespace+"dcoId";
-	private static String predicateNetworkID = dcoOntoNamespace+"networkId";
 	
 	public IndividualResponseBuilder(VitroRequest vreq, Individual individual) {
 		this.vreq = vreq;

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddDistributionGenerator.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddDistributionGenerator.java
@@ -36,12 +36,6 @@ import edu.rpi.twc.dcods.vivo.ServerInfo;
 
 public class AddDistributionGenerator extends BaseEditConfigurationGenerator implements EditConfigurationGenerator{
 
-	final static String vivoCore = "http://vivoweb.org/ontology/core#";
-	final static String dco = ServerInfo.getInstance().getDcoOntoNamespace();
-	final static String toDateCreated = dco + "dateCreated";
-	final static String valueType = vivoCore + "DateTimeValue";
-	final static String dateTimeValue = vivoCore + "dateTime";
-	final static String dateTimePrecision = vivoCore + "dateTimePrecision";
 	private String subjectUri = null;
 	private String predicateUri = null;
 	private String objectUri = null;

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCOAddDatasetGenerator.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCOAddDatasetGenerator.java
@@ -50,6 +50,7 @@ public class DCOAddDatasetGenerator extends BaseEditConfigurationGenerator imple
 		
        ServletContext ctx = vreq.getSession().getServletContext();
        String namespace = ServerInfo.getInstance().getDefaultNamespace(ctx);
+       String baseNamespace = ServerInfo.getInstance().getBaseNamespace(ctx);
        String baseURL = ServerInfo.getInstance().getBaseURL(ctx);
 
 	   EditConfigurationVTwo editConfiguration = new EditConfigurationVTwo();
@@ -61,7 +62,7 @@ public class DCOAddDatasetGenerator extends BaseEditConfigurationGenerator imple
        editConfiguration.setVarNameForPredicate("predicate");
        editConfiguration.setSubjectUri(EditConfigurationUtils.getSubjectUri(vreq));
        //editConfiguration.setFields(Map<String, FieldVTwo>.Entry);
-       editConfiguration.setUrlToReturnTo(EditConfigurationUtils.getSubjectUri(vreq).replace(namespace, baseURL));
+       editConfiguration.setUrlToReturnTo(EditConfigurationUtils.getSubjectUri(vreq).replace(namespace, baseNamespace));
        
        //System.out.println("Generator configuraiton is here\r\n"+editConfiguration.toString());
        //System.out.println("Subject URL is"+EditConfigurationUtils.getSubjectUri(vreq));

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCOAddDatasetGenerator.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCOAddDatasetGenerator.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
+import javax.servlet.ServletContext;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -36,24 +37,21 @@ import edu.rpi.twc.dcods.vivo.ServerInfo;
 
 public class DCOAddDatasetGenerator extends BaseEditConfigurationGenerator implements EditConfigurationGenerator{
 
-	final static String vivoCore = "http://vivoweb.org/ontology/core#";
-	final static String dco = ServerInfo.getInstance().getDcoOntoNamespace();
-	final static String toDateCreated = dco + "dateCreated";
-	final static String valueType = vivoCore + "DateTimeValue";
-	final static String dateTimeValue = vivoCore + "dateTime";
-	final static String dateTimePrecision = vivoCore + "dateTimePrecision";
 	private String subjectUri = null;
 	private String predicateUri = null;
 	private String objectUri = null;
 	private static String objectVarName = "newIndividual";
 	private String template = "DCOAddDatasetGenerator.ftl";
 	private boolean isObjectPropForm = false;
-	private String machineURL = "http://localhost:8080";
 	
 	@Override
 	public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,
 			HttpSession session) {
 		
+       ServletContext ctx = vreq.getSession().getServletContext();
+       String namespace = ServerInfo.getInstance().getDefaultNamespace(ctx);
+       String baseURL = ServerInfo.getInstance().getBaseURL(ctx);
+
 	   EditConfigurationVTwo editConfiguration = new EditConfigurationVTwo();
          //this is just the name, not the full path of the template
        editConfiguration.setTemplate(template);  
@@ -63,7 +61,7 @@ public class DCOAddDatasetGenerator extends BaseEditConfigurationGenerator imple
        editConfiguration.setVarNameForPredicate("predicate");
        editConfiguration.setSubjectUri(EditConfigurationUtils.getSubjectUri(vreq));
        //editConfiguration.setFields(Map<String, FieldVTwo>.Entry);
-       editConfiguration.setUrlToReturnTo(EditConfigurationUtils.getSubjectUri(vreq).replace(ServerInfo.getInstance().getDcoNamespace(), machineURL));
+       editConfiguration.setUrlToReturnTo(EditConfigurationUtils.getSubjectUri(vreq).replace(namespace, baseURL));
        
        //System.out.println("Generator configuraiton is here\r\n"+editConfiguration.toString());
        //System.out.println("Subject URL is"+EditConfigurationUtils.getSubjectUri(vreq));

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCODateCreatedFormGenerator.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DCODateCreatedFormGenerator.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import javax.servlet.http.HttpSession;
+import javax.servlet.ServletContext;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.vocabulary.XSD;
@@ -28,8 +29,6 @@ public class DCODateCreatedFormGenerator extends BaseEditConfigurationGenerator
         implements EditConfigurationGenerator {
 	
 	final static String vivoCore = "http://vivoweb.org/ontology/core#";
-	final static String dco = ServerInfo.getInstance().getDcoOntoNamespace();
-	final static String toDateCreated = dco + "dateCreated";
 	final static String valueType = vivoCore + "DateTimeValue";
 	final static String dateTimeValue = vivoCore + "dateTime";
 	final static String dateTimePrecision = vivoCore + "dateTimePrecision";
@@ -37,6 +36,8 @@ public class DCODateCreatedFormGenerator extends BaseEditConfigurationGenerator
 	@Override
 	public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,
 			HttpSession session) {
+        ServletContext ctx = vreq.getSession().getServletContext();
+
         EditConfigurationVTwo conf = new EditConfigurationVTwo();
         
         initBasics(conf, vreq);
@@ -49,15 +50,15 @@ public class DCODateCreatedFormGenerator extends BaseEditConfigurationGenerator
         conf.setVarNameForPredicate("toDateCreated");
         conf.setVarNameForObject("valueNode");
         
-        conf.setN3Optional(Arrays.asList(n3ForValue));
+        conf.setN3Optional(Arrays.asList(n3ForValue(ctx)));
         
         conf.addNewResource("valueNode", DEFAULT_NS_FOR_NEW_RESOURCE);
         
         conf.addSparqlForExistingLiteral(
-        		"dateTimeField-value", existingDateTimeValueQuery);
+        		"dateTimeField-value", existingDateTimeValueQuery(ctx));
         conf.addSparqlForExistingUris(
-        		"dateTimeField-precision", existingPrecisionQuery);
-        conf.addSparqlForExistingUris("valueNode", existingNodeQuery);
+        		"dateTimeField-precision", existingPrecisionQuery(ctx));
+        conf.addSparqlForExistingUris("valueNode", existingNodeQuery(ctx));
         
         FieldVTwo dateTimeField = new FieldVTwo().setName("dateTimeField");
         		dateTimeField.setEditElement(new DateTimeWithPrecisionVTwo(dateTimeField, 
@@ -73,28 +74,40 @@ public class DCODateCreatedFormGenerator extends BaseEditConfigurationGenerator
         return conf;
 	}
 	
-	final static String n3ForValue = 
-        "?subject <" + toDateCreated + "> ?valueNode . \n" +
+	String n3ForValue(ServletContext ctx) { 
+        String dco = ServerInfo.getInstance().getDCOURI(ctx);
+        String toDateCreated = dco + "dateCreated";
+        return "?subject <" + toDateCreated + "> ?valueNode . \n" +
         "?valueNode a <" + valueType + "> . \n" +
         "?valueNode  <" + dateTimeValue + "> ?dateTimeField-value . \n" +
         "?valueNode  <" + dateTimePrecision + "> ?dateTimeField-precision .";
+    }
 	
-	final static String existingDateTimeValueQuery = 
-        "SELECT ?existingDateTimeValue WHERE { \n" +
+	String existingDateTimeValueQuery(ServletContext ctx) {
+        String dco = ServerInfo.getInstance().getDCOURI(ctx);
+        String toDateCreated = dco + "dateCreated";
+        return "SELECT ?existingDateTimeValue WHERE { \n" +
         "?subject <" + toDateCreated + "> ?existingValueNode . \n" +
         "?existingValueNode a <" + valueType + "> . \n" +
         "?existingValueNode <" + dateTimeValue + "> ?existingDateTimeValue }";
+    }
 	
-	final static String existingPrecisionQuery = 
-        "SELECT ?existingPrecision WHERE { \n" +
+	String existingPrecisionQuery(ServletContext ctx) { 
+        String dco = ServerInfo.getInstance().getDCOURI(ctx);
+        String toDateCreated = dco + "dateCreated";
+        return "SELECT ?existingPrecision WHERE { \n" +
         "?subject <" + toDateCreated + "> ?existingValueNode . \n" +
         "?existingValueNode a <" + valueType + "> . \n" +
         "?existingValueNode <"  + dateTimePrecision + "> ?existingPrecision }";
+    }
 	
-	final static String existingNodeQuery =
-        "SELECT ?existingNode WHERE { \n" +
+	String existingNodeQuery(ServletContext ctx) {
+        String dco = ServerInfo.getInstance().getDCOURI(ctx);
+        String toDateCreated = dco + "dateCreated";
+        return "SELECT ?existingNode WHERE { \n" +
         "?subject <" + toDateCreated + "> ?existingNode . \n" +
         "?existingNode a <" + valueType + "> }";
+    }
 
 
 //Adding form specific data such as edit mode

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/ProcessRdfFormController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/ProcessRdfFormController.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletContext;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -63,14 +64,6 @@ import edu.rpi.twc.dcods.vivo.ServerInfo;
 public class ProcessRdfFormController extends FreemarkerHttpServlet{
 	
     private Log log = LogFactory.getLog(ProcessRdfFormController.class);
-    private String absoluteMachineURL = ServerInfo.getInstance().getAbsoluteMachineURL();
-    private String namespace = ServerInfo.getInstance().getDcoNamespace();
-    private String ckanURL = ServerInfo.getInstance().getCkanURL();
-    private String dcoOntoNamespace = ServerInfo.getInstance().getDcoOntoNamespace();
-    private String predicateAccessURL = dcoOntoNamespace+"accessURL";
-    private String predicateDcoID = dcoOntoNamespace+"dcoId";
-    private String predicateHasDcoId = dcoOntoNamespace+"hasDcoId";
-    private String predicateOwnedBy = dcoOntoNamespace+"ownedBy";
     
     @Override
 	protected Actions requiredActions(VitroRequest vreq) {
@@ -79,6 +72,14 @@ public class ProcessRdfFormController extends FreemarkerHttpServlet{
 
 	@Override 
 	protected ResponseValues processRequest(VitroRequest vreq) {			
+        ServletContext ctx = vreq.getSession().getServletContext() ;
+        String ckanURL = ServerInfo.getInstance().getCkanURL(ctx);
+        String dcoOntoNamespace = ServerInfo.getInstance().getDCOURI(ctx);
+        String predicateAccessURL = dcoOntoNamespace+"accessURL";
+        String predicateDcoID = dcoOntoNamespace+"dcoId";
+        String predicateHasDcoId = dcoOntoNamespace+"hasDcoId";
+        String predicateOwnedBy = dcoOntoNamespace+"ownedBy";
+
 		//get the EditConfiguration 
 		EditConfigurationVTwo configuration = EditConfigurationUtils.getEditConfiguration(vreq);
         if(configuration == null)
@@ -152,7 +153,7 @@ public class ProcessRdfFormController extends FreemarkerHttpServlet{
 	    				System.out.println("Try with instance");
 	    				ServerInfo.getInstance();
 	    				System.out.println("Try with attribute");
-	    				ServerInfo.getInstance().getCkanURL();
+	    				ServerInfo.getInstance().getCkanURL(ctx);
 	    				Client c = new Client( new Connection(ckanURL, apiKey,true),apiKey);
 	    		        
 	    		        	Dataset ds = new Dataset();

--- a/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/ProcessRdfFormController.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/ProcessRdfFormController.java
@@ -74,6 +74,7 @@ public class ProcessRdfFormController extends FreemarkerHttpServlet{
 	protected ResponseValues processRequest(VitroRequest vreq) {			
         ServletContext ctx = vreq.getSession().getServletContext() ;
         String ckanURL = ServerInfo.getInstance().getCkanURL(ctx);
+        String apiKey = ServerInfo.getInstance().getCkanApiKey(ctx);
         String dcoOntoNamespace = ServerInfo.getInstance().getDCOURI(ctx);
         String predicateAccessURL = dcoOntoNamespace+"accessURL";
         String predicateDcoID = dcoOntoNamespace+"dcoId";
@@ -147,7 +148,6 @@ public class ProcessRdfFormController extends FreemarkerHttpServlet{
 		    			//System.out.println("The name for the object is "+(submission.getLiteralsFromForm().get("label").toString().split("\\[")[1].split("\\^\\^")[0]));
 	    				String dataRepoName = submission.getLiteralsFromForm().get("label").toString().split("\\[")[1].split("\\^\\^")[0].split("\\]")[0];
 	    				
-	    				String apiKey = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
 	    				//This is a distribution instance, create a corresponded ckan instance with the name of the distribution
 	    				System.out.println("Just check ckanURL is:\r\n"+ckanURL);
 	    				System.out.println("Try with instance");

--- a/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
+++ b/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
@@ -75,7 +75,6 @@ public class CKANAPI {
 	private String rawDataString;
 	private String fileName="tempfile";
 	private String ckanDataRepoName;
-	private static String apiKey = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
 
 	public CKANAPI(){
 		
@@ -138,6 +137,8 @@ public class CKANAPI {
 				String dataFormat = datasetDownloadURL.split("\\.")[dotTokenArray-1];
 				
 				String udcoAPIAddr = ServerInfo.getInstance().getCkanURL(ctx)+"/api/rest/dataset/";
+                String apiKey = ServerInfo.getInstance().getCkanApiKey(ctx);
+
 				HttpClient httpClient = new DefaultHttpClient();
 				
 				// Get back the dataset , if there is any, coutn the number, grab thoose old ones, add new resource accordingly, genreate teh new message 
@@ -191,6 +192,7 @@ public class CKANAPI {
 				
 				try {
 					httppost.setHeader("Authorization", apiKey);
+                    httppost.setHeader("X-CKAN-API-KEY",api_key);
 					httppost.setEntity(new StringEntity(allJsonParams.toString(),"UTF-8"));
 					HttpResponse response;
 					
@@ -309,7 +311,7 @@ public class CKANAPI {
 	public String upload_rawdata(InputStream fileStream,String orgFileName, ServletContext ctx) throws IOException{
 		
 		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
-		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
+		String api_key = ServerInfo.getInstance().getCkanApiKey(ctx);
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-hhmmss",Locale.US);
@@ -379,7 +381,7 @@ public class CKANAPI {
 	public String upload_rawdata(String dataPath, ServletContext ctx) throws IOException{
        		System.out.println("data path:\r\n"+dataPath); 
 		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
-		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
+		String api_key = ServerInfo.getInstance().getCkanURL(ctx);
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-hhmmss",Locale.US);
@@ -442,7 +444,7 @@ public class CKANAPI {
 	public String upload_rawdata(String rawDataString,String fileName, ServletContext ctx) throws IOException{
 		
 		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
-		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
+		String api_key = ServerInfo.getInstance().getCkanURL(ctx);
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-hhmmss",Locale.US);

--- a/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
+++ b/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
@@ -192,7 +192,7 @@ public class CKANAPI {
 				
 				try {
 					httppost.setHeader("Authorization", apiKey);
-                    httppost.setHeader("X-CKAN-API-KEY",api_key);
+                    httppost.setHeader("X-CKAN-API-KEY",apiKey);
 					httppost.setEntity(new StringEntity(allJsonParams.toString(),"UTF-8"));
 					HttpResponse response;
 					

--- a/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
+++ b/src/edu/rpi/twc/dcods/vivo/CKANAPI.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 import java.util.UUID;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.servlet.ServletContext;
 
 import org.apache.http.client.HttpClient;
 import org.apache.commons.httpclient.HttpException;
@@ -95,8 +96,8 @@ public class CKANAPI {
 	// Check if there is already a repo exists;
 	// Return value reflects the existence of the repo
 	// If exists, then just return the url of the dataRepo;Otherwise, return an empty string
-	public String checkExistence(String dataRepoName){
-		Client client = new Client( new Connection(ServerInfo.getInstance().getCkanURL()), "");
+	public String checkExistence(String dataRepoName, ServletContext ctx){
+		Client client = new Client( new Connection(ServerInfo.getInstance().getCkanURL(ctx)), "");
 
         try {
             // Get the search results for the word gold
@@ -125,7 +126,10 @@ public class CKANAPI {
 	
 	//Associate a dataset with a data repo on ckan by name
 	//Return value is the accessURL for the corresponding data repo
-	public String associateRepoWithDataset(String dataRepoURL, String datasetDownloadURL,String rawDataName){
+	public String associateRepoWithDataset(String dataRepoURL,
+										   String datasetDownloadURL,
+										   String rawDataName,
+										   ServletContext ctx){
 		
 				
 				int arrayLen = dataRepoURL.split("/").length;
@@ -133,7 +137,7 @@ public class CKANAPI {
 				int dotTokenArray = datasetDownloadURL.split("\\.").length;
 				String dataFormat = datasetDownloadURL.split("\\.")[dotTokenArray-1];
 				
-				String udcoAPIAddr = ServerInfo.getInstance().getCkanURL()+"/api/rest/dataset/";
+				String udcoAPIAddr = ServerInfo.getInstance().getCkanURL(ctx)+"/api/rest/dataset/";
 				HttpClient httpClient = new DefaultHttpClient();
 				
 				// Get back the dataset , if there is any, coutn the number, grab thoose old ones, add new resource accordingly, genreate teh new message 
@@ -223,9 +227,9 @@ public class CKANAPI {
 	
 	
 	// HTTP GET request
-	private void sendGet() throws Exception {
+	private void sendGet(ServletContext ctx) throws Exception {
  
-		String url = ServerInfo.getInstance().getCkanURL()+"/api/3/action/package_list";
+		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/api/3/action/package_list";
 		
 		URL obj = new URL(url);
 		HttpURLConnection con = (HttpURLConnection) obj.openConnection();
@@ -263,7 +267,7 @@ public class CKANAPI {
 	}
 		
 	// HTTP POST request
-	private void sendPost() throws Exception {
+	private void sendPost(ServletContext ctx) throws Exception {
  
 		String url = "https://selfsolve.apple.com/wcResults.do";
 		URL obj = new URL(url);
@@ -302,9 +306,9 @@ public class CKANAPI {
 		System.out.println(response.toString());
  
 	}
-	public String upload_rawdata(InputStream fileStream,String orgFileName) throws IOException{
+	public String upload_rawdata(InputStream fileStream,String orgFileName, ServletContext ctx) throws IOException{
 		
-		String url = ServerInfo.getInstance().getCkanURL()+"/storage/upload_handle";
+		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
 		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
@@ -363,7 +367,7 @@ public class CKANAPI {
         String entityContentAsString = new String(out.toByteArray());
         
         HttpResponse response = client.execute(post);
-        String storagePrefix = ServerInfo.getInstance().getCkanURL()+"/storage/f/";
+        String storagePrefix = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/f/";
 	    String resourcePath = storagePrefix+url_path;
 	    System.out.println("The path for the resource is"+resourcePath);
         System.out.println(response.toString());
@@ -372,9 +376,9 @@ public class CKANAPI {
         return resourcePath;
        		
 	}
-	public String upload_rawdata(String dataPath) throws IOException{
+	public String upload_rawdata(String dataPath, ServletContext ctx) throws IOException{
        		System.out.println("data path:\r\n"+dataPath); 
-		String url = ServerInfo.getInstance().getCkanURL()+"/storage/upload_handle";
+		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
 		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
@@ -426,7 +430,7 @@ public class CKANAPI {
         System.out.println("Request being sent is \r\n"+entityContentAsString);
         
         HttpResponse response = client.execute(post);
-        String storagePrefix = ServerInfo.getInstance().getCkanURL()+"/storage/f/";
+        String storagePrefix = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/f/";
 	    String resourcePath = storagePrefix+url_path;
 	    System.out.println("The path for the resource is"+resourcePath);
         System.out.println(response.toString());
@@ -435,9 +439,9 @@ public class CKANAPI {
        
 	}
 	
-	public String upload_rawdata(String rawDataString,String fileName) throws IOException{
+	public String upload_rawdata(String rawDataString,String fileName, ServletContext ctx) throws IOException{
 		
-		String url = ServerInfo.getInstance().getCkanURL()+"/storage/upload_handle";
+		String url = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/upload_handle";
 		String api_key = "96c00a49-9604-42ca-84b1-e43674f6c0f8";
 		//Generate a date timestamp
 		long currentTime = System.currentTimeMillis();
@@ -487,7 +491,7 @@ public class CKANAPI {
         System.out.println("Request being sent is \r\n"+entityContentAsString);
         
         HttpResponse response = client.execute(post);
-        String storagePrefix = ServerInfo.getInstance().getCkanURL()+"/storage/f/";
+        String storagePrefix = ServerInfo.getInstance().getCkanURL(ctx)+"/storage/f/";
 	    String resourcePath = storagePrefix+url_path;
 	    System.out.println("The path for the resource is"+resourcePath);
         System.out.println(response.toString());
@@ -497,19 +501,19 @@ public class CKANAPI {
 
 
 	//Send metadata to CKAN and deposit
-	public int postMetaDataToCKAN(){
+	public int postMetaDataToCKAN(ServletContext ctx){
 		
 		return 0;
 	}
 	
 	//Send raw dataset to CKAN and deposit
-	public int postRawDataToCKAN(){
+	public int postRawDataToCKAN(ServletContext ctx){
 		
 		return 0;
 	}
 	
 	//Get metadata from CKAN
-	public int getMetaDataFromCKAN(){
+	public int getMetaDataFromCKAN(ServletContext ctx){
 		
 		return 0;
 	}

--- a/src/edu/rpi/twc/dcods/vivo/DCOId.java
+++ b/src/edu/rpi/twc/dcods/vivo/DCOId.java
@@ -10,6 +10,7 @@ import java.net.URL;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.servlet.ServletContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -18,7 +19,6 @@ import org.xml.sax.InputSource;
 public class DCOId {
 	
 	private String dcoId;
-	private String targetURL = ServerInfo.getInstance().getHandleURL();
 	public final String createCommand = "create";
 	public final String updateCommand = "update";
 	public final String modifyUrlCommand = "modifyurl";
@@ -28,13 +28,19 @@ public class DCOId {
 	/** generate dco id with the url as the target 
 	 *  @param url the target url of dco id
 	 * */
-	public void generateDCOId(String url) {
-		this.operate(url, "URL", this.createCommand);
+	public void generateDCOId( String url, ServletContext ctx )
+	{
+		this.operate( url, "URL", this.createCommand, ctx );
 	}
 	
 	/** generate dco id with empty target */
-	public void generateDCOId(){
-		this.operate("", "URL", this.createCommand);
+	public void generateDCOId( ServletContext ctx ){
+		this.operate("", "URL", this.createCommand, ctx );
+	}
+
+	public void modifyDCOId( String URL, ServletContext ctx )
+	{
+		operate( URL, "URL", this.modifyUrlCommand, ctx ) ;
 	}
 	
 	/** return dcoId */
@@ -69,12 +75,18 @@ public class DCOId {
 	 * @param type type of target
 	 * @param command command indicates to create, modify or update
 	 */
-	public void operate(String urlParameters, String type, String command){
+	private void operate( String urlParameters, String type, String command, ServletContext ctx )
+	{
 
-		System.out.println("The current id is "+this.dcoId);
+        System.out.println("DCOId operate " + command);
+        System.out.println("  parameters = " + urlParameters);
+        System.out.println("  type = " + type);
+		System.out.println("  the current id is "+this.dcoId);
 		urlParameters = "<handle><id>" + this.cleanDCOID(this.dcoId)+ "</id><type>" + type + "</type><value>" + urlParameters + "</value></handle>";
-		System.out.println("Request string: " + urlParameters);
-		String requestUrl = this.targetURL + command;
+		System.out.println("  request string: " + urlParameters);
+		String handleURL = ServerInfo.getInstance().getHandleURL( ctx ) ;
+		String requestUrl = handleURL + command;
+		System.out.println("  request url: " + requestUrl);
 		URL url;
 	    HttpURLConnection connection = null;  
 	    try {
@@ -120,6 +132,7 @@ public class DCOId {
 	    		Document document = builder.parse(new InputSource(new StringReader( xmlString ) ) );  
 	    		Element handleElement = (Element) document.getElementsByTagName("handle").item(0);
 	    		this.dcoId = handleElement.getElementsByTagName("id").item(0).getTextContent();          
+                System.out.println("  New dcoId " + this.dcoId);
 		    } catch (Exception e) {  
 	    		e.printStackTrace(); 
 	    		this.dcoId = null;
@@ -133,5 +146,4 @@ public class DCOId {
 	    	}
 	    }    
 	}
-
 }

--- a/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
+++ b/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
@@ -1,64 +1,89 @@
 package edu.rpi.twc.dcods.vivo;
 
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import javax.servlet.ServletContext;
+
 public class ServerInfo {
 
 	private static ServerInfo instance = null;
-	private String machineURL  = "http://info.deepcarbon.net/vivo";
-	private String absoluteMachineURL = "http://info.deepcarbon.net/vivo";
-	private String handleURL = "http://128.213.3.13:8080/dcohandleservice/services/handles/";
-	private String ckanURL = "http://data.deepcarbon.net/ckan";
-	private String dcoOntoNameSpace = "http://info.deepcarbon.net/schema#";
-	private String dcoNamespace = "http://info.deepcarbon.net";
-	private String rootName = "tw-dco@lists.rpi.edu";
-	private String rootPassword = "myts-eth-erd";
-	
-	private void ServerInfo(){
-		machineURL = "http://info.deepcarbon.net/vivo";
-		absoluteMachineURL = "http://info.deepcarbon.net/vivo";
-		handleURL = "http://128.213.3.13:8080/dcohandleservice/services/handles/";
-		ckanURL = "http://data.deepcarbon.net/ckan";
-		dcoOntoNameSpace = "http://info.deepcarbon.net/schema#";
-		dcoNamespace = "http://info.deepcarbon.net";
-		rootName = "tw-dco@lists.rpi.edu";
-		rootPassword = "myts-eth-erd";
-		
+	private String baseURL  = "DCO.baseURL";
+	private String handleURL = "DCO.handleURL";
+	private String ckanURL = "DCO.ckanURL";
+	private String dcoURI = "DCO.URI";
+	private String defaultNamespace = "Vitro.defaultNamespace";
+	private String rootName = "DCO.rootName";
+	private String rootPassword = "DCO.rootPassword";
+	private String endpoint = "DCO.endpoint";
+	private String sparqlEndpointAPI = "DCO.sparqlUpdateAPI";
+	private String sparqlQueryAPI = "DCO.sparqlQueryAPI";
+
+	private void ServerInfo()
+	{
 	}
 	
-	public static ServerInfo getInstance(){
-		if(instance==null){
-			return new ServerInfo();
-		}else{
-			return instance;
+	public static ServerInfo getInstance()
+	{
+		if( instance==null )
+		{
+			return new ServerInfo() ;
+		} else {
+			return instance ;
 		}
 	}
-	public String getRootName(){
-		return this.rootName;
+
+	private String getProperty( String property, ServletContext ctx )
+	{
+        if( ctx != null )
+            return ConfigurationProperties.getBean(ctx).getProperty(property);
+        return "" ;
+	}
+
+	public String getRootName( ServletContext ctx )
+	{
+		return getProperty( this.rootName, ctx ) ;
 	}
 	
-	public String getRootPassword(){
-		return this.rootPassword;
+	public String getRootPassword( ServletContext ctx )
+	{
+		return getProperty( this.rootPassword, ctx ) ;
 	}
 	
-	public String getMachineURL(){
-		return this.machineURL;
+	public String getHandleURL( ServletContext ctx )
+	{
+		return getProperty( this.handleURL, ctx ) ;
 	}
 	
-	public String getHandleURL(){
-		return this.handleURL;
+	public String getCkanURL( ServletContext ctx ){
+		return getProperty( this.ckanURL, ctx ) ;
 	}
 	
-	public String getCkanURL(){
-		return this.ckanURL;
+	public String getDCOURI( ServletContext ctx )
+	{
+		return getProperty( this.dcoURI, ctx ) ;
 	}
 	
-	public String getDcoOntoNamespace(){
-		return this.dcoOntoNameSpace;
+	public String getDefaultNamespace( ServletContext ctx )
+	{
+		return getProperty( this.defaultNamespace, ctx ) ;
 	}
-	
-	public String getDcoNamespace(){
-		return this.dcoNamespace;
+
+	public String getBaseURL( ServletContext ctx )
+	{
+		return getProperty( this.baseURL, ctx ) ;
 	}
-	public String getAbsoluteMachineURL(){
-		return this.absoluteMachineURL;
+
+	public String getEndpoint( ServletContext ctx )
+	{
+		return getProperty( this.endpoint, ctx ) ;
+	}
+
+	public String getSparqlUpdateAPI( ServletContext ctx )
+	{
+		return getProperty( this.sparqlEndpointAPI, ctx ) ;
+	}
+
+	public String getSparqlQueryAPI( ServletContext ctx )
+	{
+		return getProperty( this.sparqlQueryAPI, ctx ) ;
 	}
 }

--- a/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
+++ b/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
@@ -9,8 +9,10 @@ public class ServerInfo {
 	private String baseURL  = "DCO.baseURL";
 	private String handleURL = "DCO.handleURL";
 	private String ckanURL = "DCO.ckanURL";
+	private String ckanApiKey = "DCO.ckanApiKey";
 	private String dcoURI = "DCO.URI";
 	private String defaultNamespace = "Vitro.defaultNamespace";
+	private String baseNamespace = "DCO.baseNamespace";
 	private String rootName = "DCO.rootName";
 	private String rootPassword = "DCO.rootPassword";
 	private String endpoint = "DCO.endpoint";
@@ -57,6 +59,10 @@ public class ServerInfo {
 		return getProperty( this.ckanURL, ctx ) ;
 	}
 	
+	public String getCkanApiKey( ServletContext ctx ){
+		return getProperty( this.ckanApiKey, ctx ) ;
+	}
+	
 	public String getDCOURI( ServletContext ctx )
 	{
 		return getProperty( this.dcoURI, ctx ) ;
@@ -65,6 +71,11 @@ public class ServerInfo {
 	public String getDefaultNamespace( ServletContext ctx )
 	{
 		return getProperty( this.defaultNamespace, ctx ) ;
+	}
+
+	public String getBaseNamespace( ServletContext ctx )
+	{
+		return getProperty( this.baseNamespace, ctx ) ;
 	}
 
 	public String getBaseURL( ServletContext ctx )

--- a/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
+++ b/src/edu/rpi/twc/dcods/vivo/ServerInfo.java
@@ -40,59 +40,71 @@ public class ServerInfo {
         return "" ;
 	}
 
+    /* vivo root email */
 	public String getRootName( ServletContext ctx )
 	{
 		return getProperty( this.rootName, ctx ) ;
 	}
 	
+    /* vivo root password */
 	public String getRootPassword( ServletContext ctx )
 	{
 		return getProperty( this.rootPassword, ctx ) ;
 	}
 	
+    /* DCO Handle Service URL */
 	public String getHandleURL( ServletContext ctx )
 	{
 		return getProperty( this.handleURL, ctx ) ;
 	}
 	
+    /* DCO CKAN base URL. The API URL is appended to this */
 	public String getCkanURL( ServletContext ctx ){
 		return getProperty( this.ckanURL, ctx ) ;
 	}
 	
+    /* DCO CKAN API Key used to create and modify packages */
 	public String getCkanApiKey( ServletContext ctx ){
 		return getProperty( this.ckanApiKey, ctx ) ;
 	}
 	
+    /* DCO schema URI */
 	public String getDCOURI( ServletContext ctx )
 	{
 		return getProperty( this.dcoURI, ctx ) ;
 	}
 	
+    /* DCO instance namespace */
 	public String getDefaultNamespace( ServletContext ctx )
 	{
 		return getProperty( this.defaultNamespace, ctx ) ;
 	}
 
+    /* in some cases want to replace the default namespace with this namespace when going to profile pages */
 	public String getBaseNamespace( ServletContext ctx )
 	{
 		return getProperty( this.baseNamespace, ctx ) ;
 	}
 
+    /* Base URL for VIVO */
 	public String getBaseURL( ServletContext ctx )
 	{
 		return getProperty( this.baseURL, ctx ) ;
 	}
 
+    /* Fuseki endpoint */
 	public String getEndpoint( ServletContext ctx )
 	{
 		return getProperty( this.endpoint, ctx ) ;
 	}
 
+    /* VIVO SPARQL update URL */
 	public String getSparqlUpdateAPI( ServletContext ctx )
 	{
 		return getProperty( this.sparqlEndpointAPI, ctx ) ;
 	}
 
+    /* VIVO SPARQL query URL */
 	public String getSparqlQueryAPI( ServletContext ctx )
 	{
 		return getProperty( this.sparqlQueryAPI, ctx ) ;

--- a/src/edu/rpi/twc/dcods/vivo/SparqlQueryUtils.java
+++ b/src/edu/rpi/twc/dcods/vivo/SparqlQueryUtils.java
@@ -38,10 +38,11 @@ public class SparqlQueryUtils {
         System.out.println("  query = " + queryStr);
         String encodedQuery = new String();
         try {
-            encodedQuery = URIUtil.encodeQuery(queryStr);
+            encodedQuery = URIUtil.encodeWithinQuery(queryStr);
         } catch (URIException e1) {
             e1.printStackTrace();
         }
+        System.out.println("  encodedQuery = " + encodedQuery);
         String outputFormat = "&output=json";
         String url = endpoint + "/sparql?query=" + encodedQuery + outputFormat;
         HttpClient client = new DefaultHttpClient();
@@ -79,7 +80,7 @@ public class SparqlQueryUtils {
         System.out.println("  ask query = " + queryStr);
         String encodedQuery = new String();
         try {
-            encodedQuery = URIUtil.encodeQuery(queryStr);
+            encodedQuery = URIUtil.encodeWithinQuery(queryStr);
         } catch (URIException e1) {
             e1.printStackTrace();
             return false;
@@ -132,14 +133,22 @@ public class SparqlQueryUtils {
         con.setRequestProperty("User-Agent", "Mozilla/5.0");
         con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
  
-        String payload = "password=" + password + "&email=" + email + "&update=" + data;
+        try {
+            data = URIUtil.encodeWithinQuery(data);
+        } catch (URIException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        String payload = "password=" + password + "&email=" + email + "&update=";
         try {
             payload = URIUtil.encodeQuery(payload);
         } catch (URIException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        String urlParameters = payload;
+
+        String urlParameters = payload+data;
  
         // Send post request
         con.setDoOutput(true);

--- a/src/edu/rpi/twc/dcods/vivo/SparqlQueryUtils.java
+++ b/src/edu/rpi/twc/dcods/vivo/SparqlQueryUtils.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import javax.servlet.ServletContext;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.util.URIUtil;
@@ -18,135 +19,149 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class SparqlQueryUtils {
-	
-	public static final String endpoint = "https://info.deepcarbon.net/endpoint";
-	public static final String vivoSparqlUpdateAPI = "http://128.213.3.13:8080/vivo/api/sparqlUpdate";
-	
-	public static JSONArray vivoSparqlSelect(String sparqlQuery) {
-    	String queryStr = 
-    			"PREFIX dco: <" + ServerInfo.getInstance().getDcoOntoNamespace() + "> " +
-    			"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
-    			"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> " +
-    			"PREFIX vivo: <http://vivoweb.org/ontology/core#> " +
-    			"PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
-    			"PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> " +
-    			"PREFIX obo: <http://purl.obolibrary.org/obo/> " +
-    			sparqlQuery;
-    	String encodedQuery = new String();
-		try {
-			encodedQuery = URIUtil.encodeQuery(queryStr);
-		} catch (URIException e1) {
-			e1.printStackTrace();
-		}
-		String outputFormat = "&output=json";
-		String url = endpoint + "/sparql?query=" + encodedQuery + outputFormat;
-		HttpClient client = new DefaultHttpClient();
-		HttpGet request = new HttpGet(url);
-		HttpResponse response;
-		BufferedReader bufferedReader;
-		JSONArray results = new JSONArray();
-		try {
-			response = client.execute(request);
-			HttpEntity entity = response.getEntity();
-			if (entity != null) {
-				InputStream inputStream = entity.getContent();
-	            		bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-	           		StringBuilder builder = new StringBuilder();
-	            		for (String line = null; (line = bufferedReader.readLine()) != null;) {
-	                		builder.append(line).append("\n");
-	            		}
-	            		JSONObject jsonObject = new JSONObject(builder.toString());
-	            		results = jsonObject.getJSONObject("results").getJSONArray("bindings");
-	            		bufferedReader.close();
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		} finally {
-	        	client.getConnectionManager().shutdown();
-	    	}
-	return results;
+    
+    public static JSONArray vivoSparqlSelect(String sparqlQuery, ServletContext ctx) {
+        System.out.println("SparqlQueryUtils:vivoSparqlSelect");
+        String endpoint = ServerInfo.getInstance().getEndpoint( ctx );
+        System.out.println("  endpoint = " + endpoint);
+        String namespace = ServerInfo.getInstance().getDCOURI( ctx );
+        System.out.println("  namespace = " + namespace);
+        String queryStr = 
+                "PREFIX dco: <" + namespace + "> " +
+                "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
+                "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> " +
+                "PREFIX vivo: <http://vivoweb.org/ontology/core#> " +
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+                "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> " +
+                "PREFIX obo: <http://purl.obolibrary.org/obo/> " +
+                sparqlQuery;
+        System.out.println("  query = " + queryStr);
+        String encodedQuery = new String();
+        try {
+            encodedQuery = URIUtil.encodeQuery(queryStr);
+        } catch (URIException e1) {
+            e1.printStackTrace();
+        }
+        String outputFormat = "&output=json";
+        String url = endpoint + "/sparql?query=" + encodedQuery + outputFormat;
+        HttpClient client = new DefaultHttpClient();
+        HttpGet request = new HttpGet(url);
+        HttpResponse response;
+        BufferedReader bufferedReader;
+        JSONArray results = new JSONArray();
+        try {
+            response = client.execute(request);
+            HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                InputStream inputStream = entity.getContent();
+                        bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+                       StringBuilder builder = new StringBuilder();
+                        for (String line = null; (line = bufferedReader.readLine()) != null;) {
+                            builder.append(line).append("\n");
+                        }
+                        JSONObject jsonObject = new JSONObject(builder.toString());
+                        results = jsonObject.getJSONObject("results").getJSONArray("bindings");
+                        System.out.println("  results = " + results);
+                        bufferedReader.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+                client.getConnectionManager().shutdown();
+            }
+        return results;
     }
-	
-	public static boolean vivoSparqlAsk(String queryStr) {
-		String endpoint = "http://info.deepcarbon.net/endpoint";
-    	System.out.println("ASK SPARQL query: " + queryStr);
-    	String encodedQuery = new String();
-		try {
-			encodedQuery = URIUtil.encodeQuery(queryStr);
-		} catch (URIException e1) {
-			e1.printStackTrace();
-		}
-		String outputFormat = "&output=json";
-		String url = endpoint + "/sparql?query=" + encodedQuery + outputFormat;
-		HttpClient client = new DefaultHttpClient();
-		HttpGet request = new HttpGet(url);
-		HttpResponse response;
-		BufferedReader bufferedReader;
-		boolean result = Boolean.FALSE;
-		try {
-			response = client.execute(request);
-			HttpEntity entity = response.getEntity();
-			if (entity != null) {
-				InputStream inputStream = entity.getContent();
-	            		bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-	           		StringBuilder builder = new StringBuilder();
-	            		for (String line = null; (line = bufferedReader.readLine()) != null;) {
-	                		builder.append(line).append("\n");
-	            		}
-	            		JSONObject jsonObject = new JSONObject(builder.toString());
-	            		result = Boolean.parseBoolean(jsonObject.getString("boolean"));
-	            		bufferedReader.close();
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		} finally {
-	        	client.getConnectionManager().shutdown();
-	    	}
-	System.out.println("ASK query result: " + result);
-	return result;
-	}
-	
-	public static int vivoSparqlInsert(String password, String email, String data) throws Exception {	 		
-		URL obj = new URL(vivoSparqlUpdateAPI);
-		HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+    
+    public static boolean vivoSparqlAsk(String queryStr, ServletContext ctx) {
+        System.out.println("SparqlQueryUtils:vivoSparqlAsk");
+        String endpoint = ServerInfo.getInstance().getEndpoint( ctx );
+        System.out.println("  endpoint = " + endpoint);
+        System.out.println("  ask query = " + queryStr);
+        String encodedQuery = new String();
+        try {
+            encodedQuery = URIUtil.encodeQuery(queryStr);
+        } catch (URIException e1) {
+            e1.printStackTrace();
+            return false;
+        }
+        String outputFormat = "&output=json";
+        String url = endpoint + "/sparql?query=" + encodedQuery + outputFormat;
+        HttpClient client = new DefaultHttpClient();
+        HttpGet request = new HttpGet(url);
+        HttpResponse response;
+        BufferedReader bufferedReader;
+        boolean result = Boolean.FALSE;
+        try {
+            response = client.execute(request);
+            HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                InputStream inputStream = entity.getContent();
+                        bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+                       StringBuilder builder = new StringBuilder();
+                        for (String line = null; (line = bufferedReader.readLine()) != null;) {
+                            builder.append(line).append("\n");
+                        }
+                        JSONObject jsonObject = new JSONObject(builder.toString());
+                        result = Boolean.parseBoolean(jsonObject.getString("boolean"));
+                        System.out.println("  ask result = " + result);
+                        bufferedReader.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+
+        return result;
+    }
+    
+    public static int vivoSparqlInsert(String data, ServletContext ctx ) throws Exception {
+        System.out.println("SparqlQueryUtils:vivoSparqlInsert");
+        String email = ServerInfo.getInstance().getRootName( ctx );
+        System.out.println("  email = " + email);
+        String password = ServerInfo.getInstance().getRootPassword( ctx );
+        String updateAPI = ServerInfo.getInstance().getSparqlUpdateAPI( ctx );
+        System.out.println("  update API = " + updateAPI);
+        System.out.println("  data = " + data);
+        URL obj = new URL(updateAPI);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
  
-		//add reuqest header
-		con.setRequestMethod("POST");
-		con.setRequestProperty("User-Agent", "Mozilla/5.0");
-		con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+        //add reuqest header
+        con.setRequestMethod("POST");
+        con.setRequestProperty("User-Agent", "Mozilla/5.0");
+        con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
  
-		String payload = "password=" + password + "&email=" + email + "&update=" + data;
-		try {
-			payload = URIUtil.encodeQuery(payload);
-		} catch (URIException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		String urlParameters = payload;
+        String payload = "password=" + password + "&email=" + email + "&update=" + data;
+        try {
+            payload = URIUtil.encodeQuery(payload);
+        } catch (URIException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        String urlParameters = payload;
  
-		// Send post request
-		con.setDoOutput(true);
-		DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-		wr.writeBytes(urlParameters);
-		wr.flush();
-		wr.close();
+        // Send post request
+        con.setDoOutput(true);
+        DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+        wr.writeBytes(urlParameters);
+        wr.flush();
+        wr.close();
  
-		int responseCode = con.getResponseCode();
-		System.out.println("\nSending 'POST' request to URL : " + vivoSparqlUpdateAPI);
-//		System.out.println("Post parameters : " + urlParameters);
+        int responseCode = con.getResponseCode();
  
-		BufferedReader in = new BufferedReader(
-		        new InputStreamReader(con.getInputStream()));
-		String inputLine;
-		StringBuffer response = new StringBuffer();
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
  
-		while ((inputLine = in.readLine()) != null) {
-			response.append(inputLine);
-		}
-		in.close();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
  
-		//print result
-		return responseCode;
-	}
+        System.out.println("  response = " + response);
+        System.out.println("  responseCode = " + responseCode);
+        return responseCode;
+    }
 
 }


### PR DESCRIPTION
ServerInfo had a lot of hard coded values in it, values that we need
to have configurable for the different test and dev environments.
Grabbing properties from the configuration file runtime.properties
required that the servlet context be available, since properties
can be based on the context. To avoid adding a lot of different
methods to ServerInfo based on the differetn request and session objects,
like you see in the configuration file class, the caller has to grab
the servlet context themselves. No new classes had to be created, only
classes that we've modified or created. And the context was always
available.
