### PR TITLE
Fixed links in stats and slideshow

### DIFF
--- a/themes/dco/templates/page-home-slideshow.ftl
+++ b/themes/dco/templates/page-home-slideshow.ftl
@@ -16,30 +16,30 @@
         <div class="slide">
             <div id="expertiseWordCloud">
             </div>
-            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="${urls.base}/expertise-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a href="${urls.base}/expertise-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commMemberCounts">
             </div>
-            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="${urls.base}/members-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a href="${urls.base}/members-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="barchart">
             <iframe src="/dco-viz/NewMemberBarChart.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a target="_blank" href="${urls.base}/new-members-bar">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a href="${urls.base}/new-members-bar">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide">
             <div id="pubWordCloud">
             </div>
-            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="${urls.base}/pub-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a href="${urls.base}/pub-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commPubCounts">
             </div>
-            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="${urls.base}/pubs-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a href="${urls.base}/pubs-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="timeseries">
             <iframe src="/dco-viz/TotalMemberTimeSeries.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a target="_blank" href="${urls.base}/new-members-series">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a href="${urls.base}/new-members-series">Click to enlarge Chart</a>.</span>
         </div>
     </div> <!--slideshow-->
 </div> <!--container-->

--- a/themes/dco/templates/page-home-slideshow.ftl
+++ b/themes/dco/templates/page-home-slideshow.ftl
@@ -16,30 +16,30 @@
         <div class="slide">
             <div id="expertiseWordCloud">
             </div>
-            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/expertise-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="/vivo/expertise-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commMemberCounts">
             </div>
-            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/members-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="/vivo/members-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="barchart">
             <iframe src="/dco-viz/NewMemberBarChart.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/new-members-bar">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a target="_blank" href="/vivo/new-members-bar">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide">
             <div id="pubWordCloud">
             </div>
-            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/pub-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="/vivo/pub-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commPubCounts">
             </div>
-            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/pubs-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="/vivo/pubs-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="timeseries">
             <iframe src="/dco-viz/TotalMemberTimeSeries.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a target="_blank" href="https://dco.tw.rpi.edu/vivo/new-members-series">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a target="_blank" href="/vivo/new-members-series">Click to enlarge Chart</a>.</span>
         </div>
     </div> <!--slideshow-->
 </div> <!--container-->

--- a/themes/dco/templates/page-home-slideshow.ftl
+++ b/themes/dco/templates/page-home-slideshow.ftl
@@ -16,30 +16,30 @@
         <div class="slide">
             <div id="expertiseWordCloud">
             </div>
-            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="/vivo/expertise-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents areas of expertise of the various members of the DCO community. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="${urls.base}/expertise-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commMemberCounts">
             </div>
-            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="/vivo/members-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of members of the DCO per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="${urls.base}/members-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="barchart">
             <iframe src="/dco-viz/NewMemberBarChart.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a target="_blank" href="/vivo/new-members-bar">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over a given period of time. Pause the slide show to examine further. <a target="_blank" href="${urls.base}/new-members-bar">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide">
             <div id="pubWordCloud">
             </div>
-            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="/vivo/pub-cloud">Click to enlarge Cloud</a>.</span>
+            <span class="caption">This word cloud represents keywords found in publications contributed to the DCO. Pause the slide show to examine further by clicking on one of the words. <a target="_blank" href="${urls.base}/pub-cloud">Click to enlarge Cloud</a>.</span>
         </div>
         <div class="slide">
             <div id="commPubCounts">
             </div>
-            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="/vivo/pubs-pie">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of publications per science community. Pause the slide show to examine further by click on a part of the chart and then clicking more information. <a target="_blank" href="${urls.base}/pubs-pie">Click to enlarge Chart</a>.</span>
         </div>
         <div class="slide" id="timeseries">
             <iframe src="/dco-viz/TotalMemberTimeSeries.php" scrolling="no"></iframe>
-            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a target="_blank" href="/vivo/new-members-series">Click to enlarge Chart</a>.</span>
+            <span class="caption">This chart represents the number of new members of the DCO over the life of the project. Pause the slide show to examine further. <a target="_blank" href="${urls.base}/new-members-series">Click to enlarge Chart</a>.</span>
         </div>
     </div> <!--slideshow-->
 </div> <!--container-->

--- a/themes/dco/templates/page-home-stats.ftl
+++ b/themes/dco/templates/page-home-stats.ftl
@@ -2,31 +2,31 @@
     <h4>${i18n().statistics}</h4>
     <ul id="stats">
         <li>
-            <a href="${urls.base}/browse">
+            <a href="${urls.base}/people">
                 <p class="stats-count" id="members">...</p>
                 <p class="stats-type" id="members">DCO Members</p>
             </a>
         </li>
         <li>
-            <a href="${urls.base}/browse">
+            <a href="${urls.base}/publications">
                 <p class="stats-count" id="dco_publications">...</p>
                 <p class="stats-type" id="dco_publications">Publications</p>
             </a>
         </li>
         <li>
-            <a href="${urls.base}/browse">
+            <a href="${urls.base}/datasets">
                 <p class="stats-count" id="datasets">...</p>
                 <p class="stats-type" id="datasets">Datasets</p>
             </a>
         </li>
         <li>
-            <a href="${urls.base}/browse">
+            <a href="${urls.base}/projects">
                 <p class="stats-count" id="projects">...</p>
                 <p class="stats-type" id="projects">Projects</p>
             </a>
         </li>
         <li>
-            <a href="${urls.base}/browse">
+            <a href="${urls.base}/field-studies">
                 <p class="stats-count" id="field_studies">...</p>
                 <p class="stats-type" id="field_studies">Field Studies</p>
             </a>


### PR DESCRIPTION
slideshow was hardcoded to dco.tw.rpi.edu. Removed the domain name
stats was linking to the browse page, which just shows numbers. Changed this to point to browsers
