### PR TITLE
Turn on language filter

### DIFF
--- a/runtime.properties
+++ b/runtime.properties
@@ -164,7 +164,7 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
 # Show only the most appropriate data values based on the Accept-Language 
 # header supplied by the browser.  Default is false if not set.
 #
-# RDFService.languageFilter = false
+RDFService.languageFilter = true
 
 #
 # Force VIVO to use a specific language or Locale instead of those 


### PR DESCRIPTION
The labels being shown when viewed with Safari are non-English labels.  Turning on the language filter so the correct language labels are displayed.
